### PR TITLE
fix: Ensure parameter value is serialized if unknown type

### DIFF
--- a/docs/3.2.5-release-notes.md
+++ b/docs/3.2.5-release-notes.md
@@ -1,7 +1,7 @@
 ### Features
-+ Supports Streams multi modes (Event Stream, Sync)
+- Supports Streams multi modes (Event Stream, Sync)
+- Serialize complex property values (e.g. collections) as JSON rather than as strings
 
 ### Fixes
 
 - Sql Server Connector table upgrade causing error when not existing (AB#3496)
-

--- a/src/Connector.SqlServer/Features/DefaultBuildStoreDataFeature.cs
+++ b/src/Connector.SqlServer/Features/DefaultBuildStoreDataFeature.cs
@@ -93,12 +93,12 @@ namespace CluedIn.Connector.SqlServer.Features
                 var param = new SqlParameter($"@{name}", entry.Value ?? DBNull.Value);
                 try
                 {
-                    var dbType = param.DbType;
+                    _ = param.DbType;
                 }
                 catch (Exception ex)
                 {
                     logger.LogWarning(ex, "[{field}] does not map to a known sql type - will be persisted as a string.", name);
-                    param.Value = entry.Value == null ? string.Empty : entry.Value.ToString();
+                    param.Value = JsonUtility.Serialize(entry.Value);
                 }
 
                 parameters.Add(param);

--- a/test/unit/Connector.SqlServer.Test/Features/DefaultBuildStoreDataFeatureTests.cs
+++ b/test/unit/Connector.SqlServer.Test/Features/DefaultBuildStoreDataFeatureTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using AutoFixture.Xunit2;
 using CluedIn.Connector.SqlServer.Features;
+using CluedIn.Core;
 using CluedIn.Core.Data.Parts;
 using CluedIn.Core.Streams.Models;
 using Microsoft.Extensions.Logging;
@@ -121,7 +122,7 @@ namespace CluedIn.Connector.SqlServer.Unit.Tests.Features
                          "  UPDATE SET target.[Field1] = source.[Field1], target.[Field2] = source.[Field2], target.[Field3] = source.[Field3], target.[Field4] = source.[Field4], target.[Field5] = source.[Field5]" + Environment.NewLine +
                          "WHEN NOT MATCHED THEN" + Environment.NewLine +
                          "  INSERT ([Field1], [Field2], [Field3], [Field4], [Field5])" + Environment.NewLine +
-                         "  VALUES (source.[Field1], source.[Field2], source.[Field3], source.[Field4], source.[Field5]);", command.Text.Trim());            
+                         "  VALUES (source.[Field1], source.[Field2], source.[Field3], source.[Field4], source.[Field5]);", command.Text.Trim());
             Assert.Equal(data.Count, command.Parameters.Count());
 
             var paramsList = command.Parameters.ToList();
@@ -150,7 +151,7 @@ namespace CluedIn.Connector.SqlServer.Unit.Tests.Features
                              { "Field2", field2   },
                              { "InvalidField", invalidField  }
                         };
-            
+
             var execContext = _testContext.Context;
             var result = _sut.BuildStoreDataSql(execContext, providerDefinitionId, name, data, _defaultKeyFields, StreamMode.Sync, correlationId, timestamp, changeType, _logger.Object);
             var command = result.Single();
@@ -165,9 +166,9 @@ namespace CluedIn.Connector.SqlServer.Unit.Tests.Features
             Assert.Equal(3, command.Parameters.Count());
             var paramsList = command.Parameters.ToList();
 
-            Assert.Equal(paramsList[0].Value, data["Field1"]);
-            Assert.Equal(paramsList[1].Value, data["Field2"]);
-            Assert.Equal(paramsList[2].Value, data["InvalidField"].ToString());
+            Assert.Equal(data["Field1"], paramsList[0].Value);
+            Assert.Equal(data["Field2"], paramsList[1].Value);
+            Assert.Equal(JsonUtility.Serialize(data["InvalidField"]), paramsList[2].Value);
         }
 
         [Theory, InlineAutoData]
@@ -202,7 +203,7 @@ namespace CluedIn.Connector.SqlServer.Unit.Tests.Features
 
             var deleteCodesCommand = result.First();
             Assert.Equal($"DELETE FROM {name}Codes WHERE [OriginEntityCode] = @OriginEntityCode;", deleteCodesCommand.Text.Trim());
-            
+
             var deleteCodesParameters = deleteCodesCommand.Parameters.ToList();
             Assert.Single(deleteCodesParameters);
             Assert.Contains(deleteCodesParameters, p => p.ParameterName == "@OriginEntityCode" && (string)p.Value == originEntityCode);


### PR DESCRIPTION
Cherry-pick fix from `develop` to format unknown value as JSON. Should work for non-primitive values only (like arrays), as primitives should be mapped to known SQL types.