### PR TITLE
solves: not showing supported modes correctly in 330 AB#6273

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -6,7 +6,7 @@
     <_MicrosoftExtensions>3.1.5</_MicrosoftExtensions>
     <_ComponentHost>2.0.0-*</_ComponentHost>
     <_AutoFixture>4.11.0</_AutoFixture>
-    <_CluedIn>3.2.5-*</_CluedIn>
+    <_CluedIn>3.3.0-*</_CluedIn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updated the version of cluedin that it is built against