### PR TITLE
fix: Config requires camelCasing

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -5,7 +5,7 @@
 
         MUST SPECIFY IN CSPROJ AS <PackageReference Name="<depName>" />
     -->
-    <PackageReference Update="CluedIn.Connector.Common" Version="3.2.5-*" />
+    <PackageReference Update="CluedIn.Connector.Common" Version="3.3.0-alpha.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Connector.SqlServer/SqlServerConstants.cs
+++ b/src/Connector.SqlServer/SqlServerConstants.cs
@@ -1,6 +1,7 @@
 using CluedIn.Core.Providers;
 using System;
 using CluedIn.Connector.Common.Configurations;
+using CluedIn.Core;
 
 namespace CluedIn.Connector.SqlServer
 {
@@ -23,36 +24,36 @@ namespace CluedIn.Connector.SqlServer
             {
                 new Control
                 {
-                    name = CommonConfigurationNames.Host,
-                    displayName = CommonConfigurationNames.Host,
+                    name = CommonConfigurationNames.Host.ToCamelCase(),
+                    displayName = CommonConfigurationNames.Host.ToDisplayName(),
                     type = "input",
                     isRequired = true
                 },
                 new Control
                 {
-                    name = CommonConfigurationNames.DatabaseName,
-                    displayName = CommonConfigurationNames.DatabaseName,
+                    name = CommonConfigurationNames.DatabaseName.ToCamelCase(),
+                    displayName = CommonConfigurationNames.DatabaseName.ToDisplayName(),
                     type = "input",
                     isRequired = true
                 },
                 new Control
                 {
-                    name = CommonConfigurationNames.Username,
-                    displayName = CommonConfigurationNames.Username,
+                    name = CommonConfigurationNames.Username.ToCamelCase(),
+                    displayName = CommonConfigurationNames.Username.ToDisplayName(),
                     type = "input",
                     isRequired = true
                 },
                 new Control
                 {
-                    name = CommonConfigurationNames.Password,
-                    displayName = CommonConfigurationNames.Password,
+                    name = CommonConfigurationNames.Password.ToCamelCase(),
+                    displayName = CommonConfigurationNames.Password.ToDisplayName(),
                     type = "password",
                     isRequired = true
                 },
                 new Control
                 {
-                    name = CommonConfigurationNames.PortNumber,
-                    displayName = CommonConfigurationNames.PortNumber,
+                    name = CommonConfigurationNames.PortNumber.ToCamelCase(),
+                    displayName = CommonConfigurationNames.PortNumber.ToDisplayName(),
                     type = "input",
                     isRequired = false
                 }


### PR DESCRIPTION
For [AB#7136](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/7136)

Forces the config values to use camel Casing at in 3.2.5 and uses friendly display names for the auth control labels