### PR TITLE
workaround: option to disable syncing Edges table

### DIFF
--- a/src/Connector.SqlServer/Connector/SqlServerConnector.cs
+++ b/src/Connector.SqlServer/Connector/SqlServerConnector.cs
@@ -31,6 +31,7 @@ namespace CluedIn.Connector.SqlServer.Connector
         private readonly int _bulkDeleteThreshold;
         private readonly int _bulkInsertThreshold;
         private readonly bool _bulkSupported;
+        private readonly bool _syncEdgesTable;
         private readonly IList<string> _defaultKeyFields = new List<string> { "OriginEntityCode" };
 
         private readonly IFeatureStore _features;
@@ -52,6 +53,8 @@ namespace CluedIn.Connector.SqlServer.Connector
             _bulkSupported = _bulkInsertThreshold > 0 && _bulkClient != null;
             _logger.LogInformation($"{nameof(SqlServerConnector)} - bulk insert support enabled {{enabled}}",
                 _bulkSupported);
+            _syncEdgesTable =
+                ConfigurationManagerEx.AppSettings.GetValue("Streams.SqlConnector.SyncEdgesTable", true);
         }
 
         public StreamMode StreamMode { get; private set; } = StreamMode.Sync;
@@ -536,7 +539,7 @@ namespace CluedIn.Connector.SqlServer.Connector
 
             var builder = new StringBuilder();
 
-            if (StreamMode == StreamMode.Sync)
+            if (StreamMode == StreamMode.Sync && _syncEdgesTable)
                 builder.AppendLine(
                     $"DELETE FROM [{SqlStringSanitizer.Sanitize(containerName)}] where [OriginEntityCode] = {originParam.ParameterName}");
 


### PR DESCRIPTION
```
[11:57:13 DBG][CluedIn.Connector.SqlServer.Connector.SqlServerConnector] Sql Server Connector - Store Edge Data - Generated query: DELETE FROM [ljuTestStream123Edges] where [OriginEntityCode] = @OriginEntityCode
INSERT INTO [ljuTestStream123Edges] ([OriginEntityCode],[Code]) values
(@OriginEntityCode, @0)

[11:57:13 DBG][CluedIn.Connector.SqlServer.Connector.SqlServerConnector] Sql Server Connector - Store Edge Data - Generated query: DELETE FROM [ljuTestStream123Edges] where [OriginEntityCode] = @OriginEntityCode
```

Add a configuration switch to disable syncing Edges table (DELETE FROM before INSERT INTO); This is per request by SAP in order to reduce the criticality of the impediment to non-blocker and provide a viable workaround.

Due to unknown circumstances, DELETE from is executed twice while only being inserted once, thus resulting in Edges table being always empty. I suspect for every record, 2 ingestion messages get created with different data. 

Impediment due to be filled out. This PR will be referenced there.