### PR TITLE
chore: Add limit of 1024 to nvarchar field

### DIFF
--- a/src/Connector.SqlServer/Features/SqlColumnHelper.cs
+++ b/src/Connector.SqlServer/Features/SqlColumnHelper.cs
@@ -33,7 +33,7 @@ namespace CluedIn.Connector.SqlServer.Features
             //     _ => "nvarchar(max)"
             // };
 
-            return "nvarchar(max)";
+            return "nvarchar(1024)";
         }
     }
 }

--- a/test/unit/Connector.SqlServer.Test/Features/DefaultBuildCreateContainerFeatureTests.cs
+++ b/test/unit/Connector.SqlServer.Test/Features/DefaultBuildCreateContainerFeatureTests.cs
@@ -80,7 +80,7 @@ namespace CluedIn.Connector.SqlServer.Unit.Tests.Features
         {
             var expected = new StringBuilder();
             expected.AppendLine($"CREATE TABLE [{SqlStringSanitizer.Sanitize(name)}](");
-            expected.AppendJoin(", ", columns.Select(c => $"[{SqlStringSanitizer.Sanitize(c.Name)}] nvarchar(max) NULL"));
+            expected.AppendJoin(", ", columns.Select(c => $"[{SqlStringSanitizer.Sanitize(c.Name)}] nvarchar(1024) NULL"));
             expected.AppendLine(") ON[PRIMARY]");
 
             var execContext = _testContext.Context;


### PR DESCRIPTION
Zendesk ticket: https://cluedin.zendesk.com/agent/tickets/579

Partner raising a change request to limit size of nvarchar to improve performance when pulling from SQL server. Seems harmless enough.