### PR TITLE
chore: Update Connector.Common to support underscore in names

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -5,7 +5,7 @@
 
         MUST SPECIFY IN CSPROJ AS <PackageReference Name="<depName>" />
     -->
-    <PackageReference Update="CluedIn.Connector.Common" Version="3.4.0-*" />
+    <PackageReference Update="CluedIn.Connector.Common" Version="3.4.1-*" />
   </ItemGroup>
   <ItemGroup>
     <!--


### PR DESCRIPTION
With updated dependency version we can create tables with underscores. Tested and it seems to work!

That's a partial port of PR #46