### PR TITLE
feat: Introduce support for database schema configuration

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -5,7 +5,7 @@
 
         MUST SPECIFY IN CSPROJ AS <PackageReference Name="<depName>" />
     -->
-    <PackageReference Update="CluedIn.Connector.Common" Version="3.4.1-*" />
+    <PackageReference Update="CluedIn.Connector.Common" Version="3.4.2" />
   </ItemGroup>
   <ItemGroup>
     <!--

--- a/src/Connector.SqlServer/Connector/BulkSqlClient.cs
+++ b/src/Connector.SqlServer/Connector/BulkSqlClient.cs
@@ -1,6 +1,6 @@
 ﻿using System.Data;
 using System.Threading.Tasks;
-using CluedIn.Connector.Common.Helpers;
+using CluedIn.Connector.SqlServer.Utils;
 using CluedIn.Core.Connectors;
 using Microsoft.Data.SqlClient;
 
@@ -8,10 +8,10 @@ namespace CluedIn.Connector.SqlServer.Connector
 {
     public class BulkSqlClient : SqlClient, IBulkSqlClient
     {
-        public async Task ExecuteBulkAsync(IConnectorConnection config, DataTable table, string containerName)
+        public async Task ExecuteBulkAsync(IConnectorConnection config, DataTable table, SqlTableName tableName)
         {
             await using var connection = await GetConnection(config.Authentication);
-            using var bulk = new SqlBulkCopy(connection) { DestinationTableName = SqlStringSanitizer.Sanitize(containerName) };
+            using var bulk = new SqlBulkCopy(connection) { DestinationTableName = tableName.FullyQualifiedName };
             await bulk.WriteToServerAsync(table);
         }
     }

--- a/src/Connector.SqlServer/Connector/Container.cs
+++ b/src/Connector.SqlServer/Connector/Container.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using CluedIn.Connector.Common.Helpers;
+using CluedIn.Connector.SqlServer.Utils;
 using CluedIn.Core.Connectors;
 using CluedIn.Core.Data.Vocabularies;
 using CluedIn.Core.Streams.Models;
@@ -22,7 +23,7 @@ namespace CluedIn.Connector.SqlServer.Connector
         }
         public Container(string containerName, StreamMode mode)
         {
-            PrimaryTable = SqlStringSanitizer.Sanitize(containerName);
+            PrimaryTable = containerName.ToSanitizedSqlName();
             var columns = _codeEdgeColumns;
 
             if (mode == StreamMode.EventStream)
@@ -48,7 +49,7 @@ namespace CluedIn.Connector.SqlServer.Connector
                 IEnumerable<ConnectionDataType> columns,
                 IEnumerable<string> keys)
             {
-                Name = SqlStringSanitizer.Sanitize(name);
+                Name = name.ToSanitizedSqlName();
                 Columns = new List<ConnectionDataType>(columns).AsReadOnly();
                 Keys = new List<string>(keys).AsReadOnly();
             }

--- a/src/Connector.SqlServer/Connector/Container.cs
+++ b/src/Connector.SqlServer/Connector/Container.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using CluedIn.Connector.Common.Helpers;
 using CluedIn.Connector.SqlServer.Utils;
 using CluedIn.Core.Connectors;
 using CluedIn.Core.Data.Vocabularies;
@@ -19,11 +18,11 @@ namespace CluedIn.Connector.SqlServer.Connector
 
         public Container(string containerName) : this(containerName, StreamMode.Sync)
         {
-            
         }
+
         public Container(string containerName, StreamMode mode)
         {
-            PrimaryTable = containerName.ToSanitizedSqlName();
+            PrimaryTable = SqlName.FromUnsafe(containerName);
             var columns = _codeEdgeColumns;
 
             if (mode == StreamMode.EventStream)
@@ -38,7 +37,7 @@ namespace CluedIn.Connector.SqlServer.Connector
             };
         }
 
-        public string PrimaryTable { get; }
+        public SqlName PrimaryTable { get; }
 
         public IReadOnlyDictionary<string, Table> Tables { get; }
 
@@ -49,12 +48,12 @@ namespace CluedIn.Connector.SqlServer.Connector
                 IEnumerable<ConnectionDataType> columns,
                 IEnumerable<string> keys)
             {
-                Name = name.ToSanitizedSqlName();
+                Name = SqlName.FromUnsafe(name);
                 Columns = new List<ConnectionDataType>(columns).AsReadOnly();
                 Keys = new List<string>(keys).AsReadOnly();
             }
 
-            public string Name { get; }
+            public SqlName Name { get; }
 
             public IReadOnlyList<ConnectionDataType> Columns { get; }
 

--- a/src/Connector.SqlServer/Connector/IBulkSqlClient.cs
+++ b/src/Connector.SqlServer/Connector/IBulkSqlClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Data;
+﻿using CluedIn.Connector.SqlServer.Utils;
+using System.Data;
 using System.Threading.Tasks;
 using CluedIn.Core.Connectors;
 
@@ -6,6 +7,6 @@ namespace CluedIn.Connector.SqlServer.Connector
 {
     public interface IBulkSqlClient : ISqlClient
     {
-        Task ExecuteBulkAsync(IConnectorConnection config, DataTable table, string containerName);
+        Task ExecuteBulkAsync(IConnectorConnection config, DataTable table, SqlTableName tableName);
     }
 }

--- a/src/Connector.SqlServer/Connector/SqlServerConnector.cs
+++ b/src/Connector.SqlServer/Connector/SqlServerConnector.cs
@@ -28,7 +28,6 @@ namespace CluedIn.Connector.SqlServer.Connector
         private const string ChangeTypeFieldName = "ChangeType";
         private const string CorrelationIdFieldName = "CorrelationId";
         private readonly IBulkSqlClient _bulkClient;
-        private readonly ISqlClient _sqlClient;
         private readonly int _bulkDeleteThreshold;
         private readonly int _bulkInsertThreshold;
         private readonly bool _bulkSupported;
@@ -50,7 +49,6 @@ namespace CluedIn.Connector.SqlServer.Connector
                 ConfigurationManagerEx.AppSettings.GetValue("Streams.SqlConnector.BulkInsertRecordCount", 0);
             _bulkDeleteThreshold =
                 ConfigurationManagerEx.AppSettings.GetValue("Streams.SqlConnector.BulkDeleteRecordCount", 0);
-            _sqlClient = client;
             _bulkClient = client as IBulkSqlClient;
             _bulkSupported = _bulkInsertThreshold > 0 && _bulkClient != null;
             _logger.LogInformation($"{nameof(SqlServerConnector)} - bulk insert support enabled {{enabled}}",
@@ -628,7 +626,7 @@ namespace CluedIn.Connector.SqlServer.Connector
         {
             try
             {
-                var tables = await _sqlClient.GetTables(config.Authentication, name: tableName.LocalName, schema: tableName.Schema);
+                var tables = await _client.GetTables(config.Authentication, name: tableName.LocalName, schema: tableName.Schema);
 
                 return tables.Rows.Count > 0;
             }

--- a/src/Connector.SqlServer/Features/DefaultBuildCreateIndexFeature.cs
+++ b/src/Connector.SqlServer/Features/DefaultBuildCreateIndexFeature.cs
@@ -1,5 +1,5 @@
-﻿using CluedIn.Connector.Common.Helpers;
-using CluedIn.Connector.SqlServer.Connector;
+﻿using CluedIn.Connector.SqlServer.Connector;
+using CluedIn.Connector.SqlServer.Utils;
 using CluedIn.Core;
 using Microsoft.Extensions.Logging;
 using System;
@@ -12,21 +12,17 @@ namespace CluedIn.Connector.SqlServer.Features
         public virtual IEnumerable<SqlServerConnectorCommand> BuildCreateIndexSql(
             ExecutionContext executionContext,
             Guid providerDefinitionId,
-            string containerName,
+            SqlTableName tableName,
             IEnumerable<string> keys,
             ILogger logger)
         {
             if (executionContext == null)
                 throw new ArgumentNullException(nameof(executionContext));
 
-            if (string.IsNullOrWhiteSpace(containerName))
-                throw new InvalidOperationException("The Container Name must be provided.");
-
             if (logger == null)
                 throw new ArgumentNullException(nameof(logger));
 
-            var sanitizedName = SqlStringSanitizer.Sanitize(containerName);
-            var createIndexCommandText = $"CREATE INDEX [idx_{sanitizedName}] ON [{sanitizedName}]({string.Join(", ", keys)}); ";
+            var createIndexCommandText = $"CREATE INDEX [idx_{tableName.Schema}_{tableName.LocalName}] ON {tableName.FullyQualifiedName}({string.Join(", ", keys)}); ";
 
             return new[] { new SqlServerConnectorCommand { Text = createIndexCommandText } };
         }

--- a/src/Connector.SqlServer/Features/DefaultBuildDeleteDataFeature.cs
+++ b/src/Connector.SqlServer/Features/DefaultBuildDeleteDataFeature.cs
@@ -1,5 +1,6 @@
 ﻿using CluedIn.Connector.Common.Helpers;
 using CluedIn.Connector.SqlServer.Connector;
+using CluedIn.Connector.SqlServer.Utils;
 using CluedIn.Core;
 using CluedIn.Core.Data;
 using Microsoft.Data.SqlClient;
@@ -16,7 +17,7 @@ namespace CluedIn.Connector.SqlServer.Features
         public IEnumerable<SqlServerConnectorCommand> BuildDeleteDataSql(
             ExecutionContext executionContext,
             Guid providerDefinitionId,
-            string containerName,
+            SqlTableName tableName,
             string originEntityCode,
             IList<IEntityCode> codes,
             Guid? entityId,
@@ -28,31 +29,27 @@ namespace CluedIn.Connector.SqlServer.Features
             if (logger == null)
                 throw new ArgumentNullException(nameof(logger));
 
-            if (string.IsNullOrWhiteSpace(containerName))
-                throw new InvalidOperationException("The containerName must be provided.");
-
             if (!string.IsNullOrWhiteSpace(originEntityCode))
-                return ComposeDelete(containerName,
+                return ComposeDelete(tableName,
                     new Dictionary<string, object> { ["OriginEntityCode"] = originEntityCode });
             if (entityId.HasValue)
-                return ComposeDelete(containerName, new Dictionary<string, object> { ["Id"] = entityId.Value });
+                return ComposeDelete(tableName, new Dictionary<string, object> { ["Id"] = entityId.Value });
             if (codes != null)
                 return codes.SelectMany(
-                    x => ComposeDelete(containerName, new Dictionary<string, object> { ["Code"] = x }));
+                    x => ComposeDelete(tableName, new Dictionary<string, object> { ["Code"] = x }));
 
             return Enumerable.Empty<SqlServerConnectorCommand>();
         }
 
-        protected virtual IEnumerable<SqlServerConnectorCommand> ComposeDelete(string tableName,
-            IDictionary<string, object> fields)
+        protected virtual IEnumerable<SqlServerConnectorCommand> ComposeDelete(SqlTableName tableName, IDictionary<string, object> fields)
         {
-            var sqlBuilder = new StringBuilder($"DELETE FROM {SqlStringSanitizer.Sanitize(tableName)} WHERE ");
+            var sqlBuilder = new StringBuilder($"DELETE FROM {tableName.FullyQualifiedName} WHERE ");
             var clauses = new List<string>();
             var parameters = new List<SqlParameter>();
 
             foreach (var entry in fields)
             {
-                var key = SqlStringSanitizer.Sanitize(entry.Key);
+                var key = entry.Key.ToSanitizedSqlName();
                 clauses.Add($"[{key}] = @{key}");
                 parameters.Add(new SqlParameter(key, entry.Value));
             }

--- a/src/Connector.SqlServer/Features/DefaultBulkDeleteDataFeature.cs
+++ b/src/Connector.SqlServer/Features/DefaultBulkDeleteDataFeature.cs
@@ -1,4 +1,5 @@
 ﻿using CluedIn.Connector.SqlServer.Connector;
+using CluedIn.Connector.SqlServer.Utils;
 using CluedIn.Core;
 using CluedIn.Core.Connectors;
 using CluedIn.Core.Data;
@@ -14,13 +15,13 @@ namespace CluedIn.Connector.SqlServer.Features
         public Task BulkTableDelete(
             ExecutionContext executionContext,
             Guid providerDefinitionId,
-            string containerName,
+            SqlTableName tableName,
             string originEntityCode,
             IList<IEntityCode> codes,
             Guid entityId,
             int threshold,
             IBulkSqlClient client,
-            Func<Task<IConnectorConnection>> connectionFactory,
+            IConnectorConnection config,
             ILogger logger)
         {
             return Task.CompletedTask;

--- a/src/Connector.SqlServer/Features/DefaultUpgradeExistingSchemaFeature.cs
+++ b/src/Connector.SqlServer/Features/DefaultUpgradeExistingSchemaFeature.cs
@@ -1,5 +1,4 @@
-﻿using CluedIn.Connector.Common.Helpers;
-using CluedIn.Connector.SqlServer.Connector;
+﻿using CluedIn.Connector.SqlServer.Connector;
 using CluedIn.Connector.SqlServer.Utils;
 using CluedIn.Core.Connectors;
 using CluedIn.Core.Data.Vocabularies;
@@ -13,8 +12,7 @@ namespace CluedIn.Connector.SqlServer.Features
 {
     public class DefaultUpgradeExistingSchemaFeature : IUpgradeExistingSchemaFeature
     {
-        public virtual async Task VerifyExistingContainer(ISqlClient client, IConnectorConnection config,
-            StreamModel stream)
+        public virtual async Task VerifyExistingContainer(ISqlClient client, IConnectorConnection config, StreamModel stream)
         {
             var tableName = SqlTableName.FromUnsafeName(stream.ContainerName, config);
             var tables = await client.GetTableColumns(config.Authentication, tableName: tableName.LocalName, schema: tableName.Schema);

--- a/src/Connector.SqlServer/Features/DefaultUpgradeExistingSchemaFeature.cs
+++ b/src/Connector.SqlServer/Features/DefaultUpgradeExistingSchemaFeature.cs
@@ -1,5 +1,6 @@
 ﻿using CluedIn.Connector.Common.Helpers;
 using CluedIn.Connector.SqlServer.Connector;
+using CluedIn.Connector.SqlServer.Utils;
 using CluedIn.Core.Connectors;
 using CluedIn.Core.Data.Vocabularies;
 using CluedIn.Core.Streams.Models;
@@ -15,9 +16,8 @@ namespace CluedIn.Connector.SqlServer.Features
         public virtual async Task VerifyExistingContainer(ISqlClient client, IConnectorConnection config,
             StreamModel stream)
         {
-            //TODO. Check if ContainerName already sanitized.
-            var tableName = SqlStringSanitizer.Sanitize(stream.ContainerName);
-            var tables = await client.GetTableColumns(config.Authentication, tableName);
+            var tableName = SqlTableName.FromUnsafeName(stream.ContainerName, config);
+            var tables = await client.GetTableColumns(config.Authentication, tableName: tableName.LocalName, schema: tableName.Schema);
             var result = (from DataRow row in tables.Rows
                           let name = row["COLUMN_NAME"] as string
                           let rawType = row["DATA_TYPE"] as string
@@ -27,7 +27,7 @@ namespace CluedIn.Connector.SqlServer.Features
             {
                 var columnName = "TimeStamp";
                 var addTimeStampSql =
-                    $"alter table [{tableName}] add [{columnName}] {SqlColumnHelper.GetColumnType(VocabularyKeyDataType.DateTime, columnName)}";
+                    $"alter table {tableName.FullyQualifiedName} add [{columnName}] {SqlColumnHelper.GetColumnType(VocabularyKeyDataType.DateTime, columnName)}";
                 await client.ExecuteCommandAsync(config, addTimeStampSql);
             }
         }

--- a/src/Connector.SqlServer/Features/IBuildCreateContainerFeature.cs
+++ b/src/Connector.SqlServer/Features/IBuildCreateContainerFeature.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using CluedIn.Connector.SqlServer.Connector;
+using CluedIn.Connector.SqlServer.Utils;
 using CluedIn.Core;
 using CluedIn.Core.Connectors;
 using Microsoft.Extensions.Logging;
@@ -11,7 +12,7 @@ namespace CluedIn.Connector.SqlServer.Features
     {
         IEnumerable<SqlServerConnectorCommand> BuildCreateContainerSql(ExecutionContext executionContext,
             Guid providerDefinitionId,
-            string name,
+            SqlTableName tableName,
             IEnumerable<ConnectionDataType> columns,
             IEnumerable<string> keys,
             ILogger logger);

--- a/src/Connector.SqlServer/Features/IBuildCreateIndexFeature.cs
+++ b/src/Connector.SqlServer/Features/IBuildCreateIndexFeature.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using CluedIn.Connector.SqlServer.Connector;
+using CluedIn.Connector.SqlServer.Utils;
 using CluedIn.Core;
 using Microsoft.Extensions.Logging;
 
@@ -10,7 +11,7 @@ namespace CluedIn.Connector.SqlServer.Features
     {
         IEnumerable<SqlServerConnectorCommand> BuildCreateIndexSql(ExecutionContext executionContext,
             Guid providerDefinitionId,
-            string containerName,
+            SqlTableName tableName,
             IEnumerable<string> keys,
             ILogger logger);
     }

--- a/src/Connector.SqlServer/Features/IBuildDeleteDataFeature.cs
+++ b/src/Connector.SqlServer/Features/IBuildDeleteDataFeature.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using CluedIn.Connector.SqlServer.Connector;
+using CluedIn.Connector.SqlServer.Utils;
 using CluedIn.Core;
 using CluedIn.Core.Data;
 using Microsoft.Extensions.Logging;
@@ -11,7 +12,7 @@ namespace CluedIn.Connector.SqlServer.Features
     {
         IEnumerable<SqlServerConnectorCommand> BuildDeleteDataSql(ExecutionContext executionContext,
             Guid providerDefinitionId,
-            string containerName,
+            SqlTableName tableName,
             string originEntityCode,
             IList<IEntityCode> codes,
             Guid? entityId,

--- a/src/Connector.SqlServer/Features/IBuildStoreDataFeature.cs
+++ b/src/Connector.SqlServer/Features/IBuildStoreDataFeature.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using CluedIn.Connector.SqlServer.Connector;
+using CluedIn.Connector.SqlServer.Utils;
 using CluedIn.Core;
 using Microsoft.Extensions.Logging;
 
@@ -10,7 +11,7 @@ namespace CluedIn.Connector.SqlServer.Features
     {
         IEnumerable<SqlServerConnectorCommand> BuildStoreDataSql(ExecutionContext executionContext,
             Guid providerDefinitionId,
-            string containerName,
+            SqlTableName tableName,
             IDictionary<string, object> data,
             IList<string> keys,
             ILogger logger);

--- a/src/Connector.SqlServer/Features/IBuildStoreDataForMode.cs
+++ b/src/Connector.SqlServer/Features/IBuildStoreDataForMode.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using CluedIn.Connector.SqlServer.Connector;
+using CluedIn.Connector.SqlServer.Utils;
 using CluedIn.Core;
 using CluedIn.Core.Data.Parts;
 using CluedIn.Core.Streams.Models;
@@ -12,7 +13,7 @@ namespace CluedIn.Connector.SqlServer.Features
     {
         IEnumerable<SqlServerConnectorCommand> BuildStoreDataSql(ExecutionContext executionContext,
             Guid providerDefinitionId,
-            string containerName,
+            SqlTableName tableName,
             IDictionary<string, object> data,
             IList<string> keys,
             StreamMode mode,

--- a/src/Connector.SqlServer/Features/IBulkDeleteDataFeature.cs
+++ b/src/Connector.SqlServer/Features/IBulkDeleteDataFeature.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using CluedIn.Connector.SqlServer.Connector;
+using CluedIn.Connector.SqlServer.Utils;
 using CluedIn.Core;
 using CluedIn.Core.Connectors;
 using CluedIn.Core.Data;
@@ -13,13 +14,13 @@ namespace CluedIn.Connector.SqlServer.Features
     {
         Task BulkTableDelete(ExecutionContext executionContext,
             Guid providerDefinitionId,
-            string containerName,
+            SqlTableName tableName,
             string originEntityCode,
             IList<IEntityCode> codes,
             Guid entityId,
             int threshold,
             IBulkSqlClient client,
-            Func<Task<IConnectorConnection>> connectionFactory,
+            IConnectorConnection config,
             ILogger logger);
     }
 }

--- a/src/Connector.SqlServer/Features/IBulkStoreDataFeature.cs
+++ b/src/Connector.SqlServer/Features/IBulkStoreDataFeature.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using CluedIn.Connector.SqlServer.Connector;
+using CluedIn.Connector.SqlServer.Utils;
 using CluedIn.Core;
 using CluedIn.Core.Connectors;
 using Microsoft.Extensions.Logging;
@@ -13,11 +14,11 @@ namespace CluedIn.Connector.SqlServer.Features
         Task BulkTableUpdate(
             ExecutionContext executionContext,
             Guid providerDefinitionId,
-            string containerName,
+            SqlTableName tableName,
             IDictionary<string, object> data,
             int threshold,
             IBulkSqlClient client,
-            Func<Task<IConnectorConnection>> connectionFactory,
+            IConnectorConnection config,
             ILogger logger);
     }
 }

--- a/src/Connector.SqlServer/Properties/AssemblyInfo.cs
+++ b/src/Connector.SqlServer/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+[assembly: InternalsVisibleTo("CluedIn.Connector.SqlServer.Unit.Tests")]

--- a/src/Connector.SqlServer/SqlServerConnectorProvider.cs
+++ b/src/Connector.SqlServer/SqlServerConnectorProvider.cs
@@ -3,6 +3,7 @@ using CluedIn.Connector.Common;
 using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using CluedIn.Connector.Common.Configurations;
+using CluedIn.Connector.SqlServer.Utils;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
@@ -20,7 +21,7 @@ namespace CluedIn.Connector.SqlServer
         }
 
         protected override IEnumerable<string> ProviderNameParts =>
-            new[] { SqlServerConstants.KeyName.Host, SqlServerConstants.KeyName.DatabaseName };
+            new[] { SqlServerConstants.KeyName.Host, SqlServerConstants.KeyName.Schema, SqlServerConstants.KeyName.DatabaseName };
 
         public override string Schedule(DateTimeOffset relativeDateTime, bool webHooksEnabled)
             => $"{relativeDateTime.Minute} 0/23 * * *";
@@ -30,31 +31,44 @@ namespace CluedIn.Connector.SqlServer
 
         public override Task<AccountInformation> GetAccountInformation(ExecutionContext context, CrawlJobData jobData, Guid organizationId, Guid userId, Guid providerDefinitionId)
         {
-            // base class does not map to original spec of this connector with dot-seperated values
+            // base class does not map to original spec of this connector with dot-separated values
 
-            if (jobData == null)
-            {
-                throw new ArgumentNullException(nameof(jobData));
-            }
+            if (jobData == null) throw new ArgumentNullException(nameof(jobData));
 
             if (!(jobData is CrawlJobDataWrapper dataWrapper))
             {
-                throw new ArgumentException(
-                    "Wrong CrawlJobData type", nameof(jobData));
+                throw new ArgumentException("Wrong CrawlJobData type", nameof(jobData));
             }
 
             var partsFound = new List<string>();
             foreach (var key in ProviderNameParts)
+            {
                 if (dataWrapper.Configurations.TryGetValue(key, out var value) && value != null)
+                {
+                    // Do not add schema name if it's the default. So account would look `localhost.ExportTarget2` instead of `localhost.dbo.ExportTarget2`
+                    // 
+                    // The primary reason is backward compatibility. CluedIn does not create multiple accounts pointing to the same object.
+                    // Before schema support introduction all accounts did not contain schema, so if we change the rule, it will be possible to
+                    // create new export targets pointing to same database as the existing ones (as the name will differ due to a presence of the schema in it).
+                    // We solve that if we don't embed default schema, so it will be reduced to the legacy behavior for the default schema.
+                    //
+                    // Also it looks nicer in majority of cases when you don't specify the schema :)
+                    if (SqlServerConstants.KeyName.Schema.Equals(key, StringComparison.Ordinal) && SqlTableName.DefaultSchema.Equals(value))
+                    {
+                        continue;
+                    }
+
                     partsFound.Add(value.ToString());
+                }
+            }
 
             var account = string.Join('.', partsFound);
             if (string.IsNullOrEmpty(account))
+            {
                 account = ".";
+            }
 
             return Task.FromResult(new AccountInformation(account, account));
-
-
         }
     }
 }

--- a/src/Connector.SqlServer/SqlServerConstants.cs
+++ b/src/Connector.SqlServer/SqlServerConstants.cs
@@ -1,7 +1,6 @@
 using CluedIn.Core.Providers;
 using System;
 using CluedIn.Connector.Common.Configurations;
-using CluedIn.Core;
 
 namespace CluedIn.Connector.SqlServer
 {
@@ -10,6 +9,7 @@ namespace CluedIn.Connector.SqlServer
         public struct KeyName
         {
             public const string Host = "host";
+            public const string Schema = "schema";
             public const string DatabaseName = "databaseName";
             public const string Username = "username";
             public const string Password = "password";
@@ -63,6 +63,13 @@ namespace CluedIn.Connector.SqlServer
                 {
                     name = KeyName.PortNumber,
                     displayName = CommonConfigurationNames.PortNumber.ToDisplayName(),
+                    type = "input",
+                    isRequired = false
+                },
+                new Control
+                {
+                    name = KeyName.Schema,
+                    displayName = CommonConfigurationNames.Schema.ToDisplayName(),
                     type = "input",
                     isRequired = false
                 }

--- a/src/Connector.SqlServer/Utils/ConnectorConnectionExtensions.cs
+++ b/src/Connector.SqlServer/Utils/ConnectorConnectionExtensions.cs
@@ -7,7 +7,7 @@ namespace CluedIn.Connector.SqlServer.Utils
         /// <summary>
         /// Returns sanitized configured schema or default one if it's not specified by user.
         /// </summary>
-        public static string GetSchema(this IConnectorConnection config)
+        public static SqlName GetSchema(this IConnectorConnection config)
         {
             if (config.Authentication.TryGetValue(SqlServerConstants.KeyName.Schema, out var value) && value is string schema)
             {
@@ -15,11 +15,11 @@ namespace CluedIn.Connector.SqlServer.Utils
 
                 if (!string.IsNullOrEmpty(sanitizedSchema))
                 {
-                    return sanitizedSchema;
+                    return SqlName.FromSanitized(schema);
                 }
             }
 
-            return SqlTableName.DefaultSchema;
+            return SqlName.FromSanitized(SqlTableName.DefaultSchema);
         }
     }
 }

--- a/src/Connector.SqlServer/Utils/ConnectorConnectionExtensions.cs
+++ b/src/Connector.SqlServer/Utils/ConnectorConnectionExtensions.cs
@@ -1,0 +1,25 @@
+﻿using CluedIn.Core.Connectors;
+
+namespace CluedIn.Connector.SqlServer.Utils
+{
+    internal static class ConnectorConnectionExtensions
+    {
+        /// <summary>
+        /// Returns sanitized configured schema or default one if it's not specified by user.
+        /// </summary>
+        public static string GetSchema(this IConnectorConnection config)
+        {
+            if (config.Authentication.TryGetValue(SqlServerConstants.KeyName.Schema, out var value) && value is string schema)
+            {
+                var sanitizedSchema = schema.ToSanitizedSqlName();
+
+                if (!string.IsNullOrEmpty(sanitizedSchema))
+                {
+                    return sanitizedSchema;
+                }
+            }
+
+            return SqlTableName.DefaultSchema;
+        }
+    }
+}

--- a/src/Connector.SqlServer/Utils/SqlName.cs
+++ b/src/Connector.SqlServer/Utils/SqlName.cs
@@ -1,0 +1,46 @@
+﻿using CluedIn.Core.Connectors;
+using System;
+
+namespace CluedIn.Connector.SqlServer.Utils
+{
+    public readonly struct SqlName
+    {
+        public string Value { get; }
+
+        private SqlName(string value)
+        {
+            Value = value;
+        }
+
+        public static SqlName FromUnsafe(string value)
+        {
+            if (string.IsNullOrEmpty(value)) throw new ArgumentException("Value cannot be null or empty.", nameof(value));
+
+            var sanitizedValue = value.ToSanitizedSqlName();
+            if (string.IsNullOrEmpty(sanitizedValue))
+            {
+                throw new ArgumentException("Name cannot be empty after being sanitized", nameof(value));
+            }
+
+            return new SqlName(sanitizedValue);
+        }
+
+        public static SqlName FromSanitized(string value)
+        {
+            if (string.IsNullOrEmpty(value)) throw new ArgumentException("Value cannot be null or empty.", nameof(value));
+
+            return new SqlName(value);
+        }
+
+        public static implicit operator string (SqlName value)
+        {
+            return value.Value;
+        }
+
+        public override string ToString() => Value;
+
+        public SqlTableName ToTableName(SqlName schema) => new SqlTableName(this, schema);
+
+        public SqlTableName ToTableName(IConnectorConnection config) => new SqlTableName(this, config.GetSchema());
+    }
+}

--- a/src/Connector.SqlServer/Utils/SqlTableName.cs
+++ b/src/Connector.SqlServer/Utils/SqlTableName.cs
@@ -1,0 +1,54 @@
+﻿using CluedIn.Connector.Common.Helpers;
+using CluedIn.Core.Connectors;
+using System;
+
+#nullable enable
+
+namespace CluedIn.Connector.SqlServer.Utils
+{
+    public sealed class SqlTableName
+    {
+        public const string DefaultSchema = "dbo";
+
+        /// <summary>
+        /// Creates sanitized table name from unsafe name
+        /// </summary>
+        public static SqlTableName FromUnsafeName(string rawTableName, string sanitizedSchema)
+        {
+            if (string.IsNullOrEmpty(rawTableName)) throw new ArgumentException("Value cannot be null or empty.", nameof(rawTableName));
+            if (string.IsNullOrEmpty(sanitizedSchema)) throw new ArgumentException("Value cannot be null or empty.", nameof(sanitizedSchema));
+
+            var sanitizedName = rawTableName.ToSanitizedSqlName();
+            if (string.IsNullOrEmpty(sanitizedName))
+            {
+                throw new ArgumentException("Table name cannot be empty after being sanitized", nameof(sanitizedSchema));
+            }
+
+            return new SqlTableName(sanitizedName, sanitizedSchema);
+        }
+
+        /// <summary>
+        /// Creates sanitized table name from unsafe name
+        /// </summary>
+        public static SqlTableName FromUnsafeName(string rawTableName, IConnectorConnection config) =>
+            FromUnsafeName(rawTableName, config.GetSchema());
+
+        public string Schema { get; }
+
+        /// <summary>
+        /// Returns value in [Schema].[Name] format, which is suitable for query embedding
+        /// </summary>
+        public string FullyQualifiedName { get; }
+
+        public string LocalName { get; }
+
+        private SqlTableName(string sanitizedName, string schema)
+        {
+            Schema = schema;
+            LocalName = sanitizedName;
+            FullyQualifiedName = $"[{schema}].[{sanitizedName}]";
+        }
+
+        public override string ToString() => FullyQualifiedName;
+    }
+}

--- a/src/Connector.SqlServer/Utils/SqlTableName.cs
+++ b/src/Connector.SqlServer/Utils/SqlTableName.cs
@@ -1,6 +1,4 @@
-﻿using CluedIn.Connector.Common.Helpers;
-using CluedIn.Core.Connectors;
-using System;
+﻿using CluedIn.Core.Connectors;
 
 #nullable enable
 
@@ -13,18 +11,9 @@ namespace CluedIn.Connector.SqlServer.Utils
         /// <summary>
         /// Creates sanitized table name from unsafe name
         /// </summary>
-        public static SqlTableName FromUnsafeName(string rawTableName, string sanitizedSchema)
+        public static SqlTableName FromUnsafeName(string rawTableName, SqlName schema)
         {
-            if (string.IsNullOrEmpty(rawTableName)) throw new ArgumentException("Value cannot be null or empty.", nameof(rawTableName));
-            if (string.IsNullOrEmpty(sanitizedSchema)) throw new ArgumentException("Value cannot be null or empty.", nameof(sanitizedSchema));
-
-            var sanitizedName = rawTableName.ToSanitizedSqlName();
-            if (string.IsNullOrEmpty(sanitizedName))
-            {
-                throw new ArgumentException("Table name cannot be empty after being sanitized", nameof(sanitizedSchema));
-            }
-
-            return new SqlTableName(sanitizedName, sanitizedSchema);
+            return new SqlTableName(SqlName.FromUnsafe(rawTableName), schema);
         }
 
         /// <summary>
@@ -33,20 +22,20 @@ namespace CluedIn.Connector.SqlServer.Utils
         public static SqlTableName FromUnsafeName(string rawTableName, IConnectorConnection config) =>
             FromUnsafeName(rawTableName, config.GetSchema());
 
-        public string Schema { get; }
+        public SqlName Schema { get; }
 
         /// <summary>
         /// Returns value in [Schema].[Name] format, which is suitable for query embedding
         /// </summary>
         public string FullyQualifiedName { get; }
 
-        public string LocalName { get; }
+        public SqlName LocalName { get; }
 
-        private SqlTableName(string sanitizedName, string schema)
+        public SqlTableName(SqlName localName, SqlName schema)
         {
             Schema = schema;
-            LocalName = sanitizedName;
-            FullyQualifiedName = $"[{schema}].[{sanitizedName}]";
+            LocalName = localName;
+            FullyQualifiedName = $"[{schema}].[{localName}]";
         }
 
         public override string ToString() => FullyQualifiedName;

--- a/src/Connector.SqlServer/Utils/StringExtensions.cs
+++ b/src/Connector.SqlServer/Utils/StringExtensions.cs
@@ -1,0 +1,12 @@
+﻿using CluedIn.Connector.Common.Helpers;
+
+namespace CluedIn.Connector.SqlServer.Utils
+{
+    internal static class StringExtensions
+    {
+        /// <summary>
+        /// Sanitize potentially unsafe value to be a valid SQL name
+        /// </summary>
+        public static string ToSanitizedSqlName(this string value) => SqlStringSanitizer.Sanitize(value);
+    }
+}

--- a/test/unit/Connector.SqlServer.Test/SqlGenerationTests.cs
+++ b/test/unit/Connector.SqlServer.Test/SqlGenerationTests.cs
@@ -34,7 +34,7 @@ namespace CluedIn.Connector.SqlServer.Unit.Tests
         [InlineAutoData("tableName")]
         public void StoreEdgeDataWorks(string name, string originEntityCode, string correlationId, List<string> edges)
         {
-            var tableName = SqlTableName.FromUnsafeName(name, SqlTableName.DefaultSchema);
+            var tableName = SqlTableName.FromUnsafeName(name, SqlName.FromSanitized(SqlTableName.DefaultSchema));
             var result = Sut.BuildEdgeStoreDataSql(tableName, originEntityCode, correlationId, edges, out var param);
             Assert.Equal(edges.Count + 2, param.Count()); // params will also include origin entity code
             Assert.Contains(param, p => p.ParameterName == "@OriginEntityCode" && p.Value.Equals(originEntityCode));
@@ -58,7 +58,7 @@ namespace CluedIn.Connector.SqlServer.Unit.Tests
         [InlineAutoData("tableName")]
         public void StoreEdgeData_NoEdges_Works(string name, string originEntityCode, string correlationId)
         {
-            var tableName = SqlTableName.FromUnsafeName(name, SqlTableName.DefaultSchema);
+            var tableName = SqlTableName.FromUnsafeName(name, SqlName.FromSanitized(SqlTableName.DefaultSchema));
             var edges = new List<string>();
             var result = Sut.BuildEdgeStoreDataSql(tableName, originEntityCode, correlationId, edges, out var param);
             Assert.Equal(2, param.Count()); // params will also include origin entity code and correlationid

--- a/test/unit/Connector.SqlServer.Test/SqlGenerationTests.cs
+++ b/test/unit/Connector.SqlServer.Test/SqlGenerationTests.cs
@@ -1,4 +1,5 @@
 ﻿using AutoFixture.Xunit2;
+using CluedIn.Connector.SqlServer.Utils;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -33,7 +34,8 @@ namespace CluedIn.Connector.SqlServer.Unit.Tests
         [InlineAutoData("tableName")]
         public void StoreEdgeDataWorks(string name, string originEntityCode, string correlationId, List<string> edges)
         {
-            var result = Sut.BuildEdgeStoreDataSql(name, originEntityCode, correlationId, edges, out var param);
+            var tableName = SqlTableName.FromUnsafeName(name, SqlTableName.DefaultSchema);
+            var result = Sut.BuildEdgeStoreDataSql(tableName, originEntityCode, correlationId, edges, out var param);
             Assert.Equal(edges.Count + 2, param.Count()); // params will also include origin entity code
             Assert.Contains(param, p => p.ParameterName == "@OriginEntityCode" && p.Value.Equals(originEntityCode));
             for (var index = 0; index < edges.Count; index++)
@@ -43,8 +45,8 @@ namespace CluedIn.Connector.SqlServer.Unit.Tests
 
             var expectedLines = new List<string>
             {
-                $"DELETE FROM [{name}] where [OriginEntityCode] = @OriginEntityCode",
-                $"INSERT INTO [{name}] ([OriginEntityCode],[Code]) values",
+                $"DELETE FROM [{tableName.Schema}].[{tableName.LocalName}] where [OriginEntityCode] = @OriginEntityCode",
+                $"INSERT INTO [{tableName.Schema}].[{tableName.LocalName}] ([OriginEntityCode],[Code]) values",
                 string.Join(", ", Enumerable.Range(0, edges.Count).Select(i => $"(@OriginEntityCode, @{i})"))
             };
 
@@ -56,11 +58,12 @@ namespace CluedIn.Connector.SqlServer.Unit.Tests
         [InlineAutoData("tableName")]
         public void StoreEdgeData_NoEdges_Works(string name, string originEntityCode, string correlationId)
         {
+            var tableName = SqlTableName.FromUnsafeName(name, SqlTableName.DefaultSchema);
             var edges = new List<string>();
-            var result = Sut.BuildEdgeStoreDataSql(name, originEntityCode, correlationId, edges, out var param);
+            var result = Sut.BuildEdgeStoreDataSql(tableName, originEntityCode, correlationId, edges, out var param);
             Assert.Equal(2, param.Count()); // params will also include origin entity code and correlationid
             Assert.Contains(param, p => p.ParameterName == "@OriginEntityCode" && p.Value.Equals(originEntityCode));
-            Assert.Equal($"DELETE FROM [{name}] where [OriginEntityCode] = @OriginEntityCode", result.Trim());
+            Assert.Equal($"DELETE FROM [{tableName.Schema}].[{tableName.LocalName}] where [OriginEntityCode] = @OriginEntityCode", result.Trim());
         }
     }
 }

--- a/test/unit/Connector.SqlServer.Test/Utils/SqlTableNameTests.cs
+++ b/test/unit/Connector.SqlServer.Test/Utils/SqlTableNameTests.cs
@@ -14,7 +14,7 @@ namespace CluedIn.Connector.SqlServer.Unit.Tests.Utils
         [InlineAutoData("")]
         [InlineAutoData("\t\t   ")]
         public void FromUnsafeName_ShouldThrowForInvalidName_WhenUseStringOverload(string tableName,
-            string schema)
+            SqlName schema)
         {
             // arrange
             Action action = () => SqlTableName.FromUnsafeName(tableName, schema);

--- a/test/unit/Connector.SqlServer.Test/Utils/SqlTableNameTests.cs
+++ b/test/unit/Connector.SqlServer.Test/Utils/SqlTableNameTests.cs
@@ -1,0 +1,44 @@
+﻿using AutoFixture.Xunit2;
+using CluedIn.Connector.SqlServer.Utils;
+using CluedIn.Core.Connectors;
+using FluentAssertions;
+using System;
+using Xunit;
+
+namespace CluedIn.Connector.SqlServer.Unit.Tests.Utils
+{
+    public class SqlTableNameTests
+    {
+        [Theory]
+        [InlineAutoData(null)]
+        [InlineAutoData("")]
+        [InlineAutoData("\t\t   ")]
+        public void FromUnsafeName_ShouldThrowForInvalidName_WhenUseStringOverload(string tableName,
+            string schema)
+        {
+            // arrange
+            Action action = () => SqlTableName.FromUnsafeName(tableName, schema);
+
+            // act
+            // assert
+            action.Should().Throw<ArgumentException>();
+        }
+
+        [Theory]
+        [InlineAutoData(null)]
+        [InlineAutoData("")]
+        [InlineAutoData("\t\t   ")]
+        public void FromUnsafeName_ShouldThrowForInvalidName_WhenUseConfigOverload(string tableName,
+            string schema)
+        {
+            // arrange
+            var config = new ConnectorConnectionBase { Authentication = { [SqlServerConstants.KeyName.Schema] = schema } };
+
+            Action action = () => SqlTableName.FromUnsafeName(tableName, config);
+
+            // act
+            // assert
+            action.Should().Throw<ArgumentException>();
+        }
+    }
+}


### PR DESCRIPTION
## Description

Work Item: [AB#17339](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/17339)

Allow to customize schema when creating a new export target. If schema is not specified, the default `dbo` is used.

Some remarks about the implementation:
- If non-default schema is specified, we embed it to the name (account ID) of the export target. If not - we go without:
    ![image](https://user-images.githubusercontent.com/1074182/203524941-da2fff0a-b3ae-4ed5-bcc9-23f450cff6c9.png)
    This way we can create multiple export targets pointing to same database

- Bumped the dependency to consume changes in the common connectors.
- Has breaking changes around, as I'm passing `SqlTableName` instead of string to remember schema information.

I've tested it for the basic scenarios and it seems to work. It does not work if Batch is configured, but that's because it's already broken as of today. Decided to not fix that in this PR.

