### PR TITLE
fix: Filter on table when verifying indexes

### DIFF
--- a/src/Connector.SqlServer/Features/VerifyUniqueIndexFeature.cs
+++ b/src/Connector.SqlServer/Features/VerifyUniqueIndexFeature.cs
@@ -25,10 +25,10 @@ Declare @EntitiesWithDuplicatesExists AS BIT
 SET @EntitiesWithDuplicatesExists = 0
 
 IF EXISTS (
-SELECT TOP(1) [Id]
-   FROM {tableName}
-   GROUP BY [Id]
-   HAVING COUNT(Id) > 1)
+  SELECT TOP(1) [Id]
+  FROM {tableName.FullyQualifiedName}
+  GROUP BY [Id]
+  HAVING COUNT(Id) > 1)
 BEGIN
   SET @EntitiesWithDuplicatesExists = 1
 END
@@ -40,10 +40,16 @@ BEGIN
 END
 ELSE
 BEGIN
-  IF EXISTS (SELECT * FROM sys.indexes WHERE name = '{indexName}' AND is_unique = 'false')
+  IF EXISTS (
+    SELECT *
+    FROM sys.indexes
+    WHERE
+      object_id = (SELECT object_id FROM sys.objects WHERE name = '{tableName.LocalName}') AND
+      name = '{indexName}' AND
+      is_unique = 'false')
   BEGIN
     PRINT 'Adding index'
-	DROP INDEX {indexName} ON {tableName}
+	DROP INDEX {indexName} ON {tableName.FullyQualifiedName}
 	{createIndexCommand}
   END
 


### PR DESCRIPTION
Work Item ID: [AB#17870](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/17870)

We need to filter on table name, since other tables might have the indexes named the same as the one we're trying to drop.