### PR TITLE
fix: Copy datatypes when creating tables, to avoid duplicates on retry

### DIFF
--- a/src/Connector.SqlServer/Connector/SqlServerConnector.cs
+++ b/src/Connector.SqlServer/Connector/SqlServerConnector.cs
@@ -316,7 +316,8 @@ namespace CluedIn.Connector.SqlServer.Connector
                 var container = new Container(model.Name, StreamMode);
                 var codesTable = container.Tables["Codes"];
 
-                var connectionDataTypes = model.DataTypes;
+                // We need to copy the datatypes, otherwise we're adding to the model, which will cause problems if we have a timeout
+                var connectionDataTypes = model.DataTypes.ToList();
                 if (StreamMode == StreamMode.EventStream)
                 {
                     connectionDataTypes.Add(new ConnectionDataType


### PR DESCRIPTION
Work Item ID: [AB#18519](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/18519)

We need to copy the datatypes from the model, otherwise we're adding to them, and will have duplicates on retry.