### PR TITLE
chore: Update common connector reference to 3.4.4

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -5,7 +5,7 @@
 
         MUST SPECIFY IN CSPROJ AS <PackageReference Name="<depName>" />
     -->
-    <PackageReference Update="CluedIn.Connector.Common" Version="[3.4.3-beta.3,3.4.3)" />
+    <PackageReference Update="CluedIn.Connector.Common" Version="[3.4.4,3.5.0)" />
   </ItemGroup>
   <ItemGroup>
     <!--


### PR DESCRIPTION
Work item ID: [AB#18931](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/18931)

Update reference to released version