### PR TITLE
fix: Remove grants execution on created type

### DIFF
--- a/src/Connector.SqlServer/Features/AddCustomTypesFeature.cs
+++ b/src/Connector.SqlServer/Features/AddCustomTypesFeature.cs
@@ -8,12 +8,7 @@
 IF Type_ID(N'CodeTableType') IS NULL
 BEGIN
   CREATE TYPE CodeTableType AS TABLE( Code nvarchar(1024));
-END
-
-GRANT EXEC ON TYPE::CodeTableType TO PUBLIC
-GRANT REFERENCES ON TYPE::CodeTableType TO PUBLIC
-GRANT VIEW DEFINITION ON TYPE::CodeTableType TO PUBLIC;
-";
+END";
         }
     }
 }


### PR DESCRIPTION
Permission to types should be preconfigured for the write user.
There is no need to grant permissions on the created type.

The write user should be granted the following permissions:

```
GRANT CREATE TYPE TO writeUser

GRANT ALTER TO writeUser
GRANT EXECUTE TO writeUser

-- If using a schema name
-- GRANT ALTER ON SCHEMA :: mySchema TO writeUser
-- GRANT EXECUTE ON SCHEMA :: mySchema TO writeUser
```