### PR TITLE
feat: Throw exception if old table exists

### DIFF
--- a/src/Connector.SqlServer/Connector/SqlServerConnector.cs
+++ b/src/Connector.SqlServer/Connector/SqlServerConnector.cs
@@ -1,4 +1,5 @@
 ﻿using CluedIn.Connector.Common.Connectors;
+using CluedIn.Connector.SqlServer.Exceptions;
 using CluedIn.Connector.SqlServer.Utils;
 using CluedIn.Connector.SqlServer.Utils.TableDefinitions;
 using CluedIn.Core;
@@ -11,6 +12,7 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -39,29 +41,72 @@ namespace CluedIn.Connector.SqlServer.Connector
 
         public override async Task VerifyExistingContainer(ExecutionContext executionContext, IReadOnlyStreamModel streamModel)
         {
+            Debugger.Launch();
+
             await ExecuteWithRetryAsync(async () =>
             {
+                this._logger.LogError("Verifying existing container for stream: {streamId}", streamModel.Id);
+
                 var config = await AuthenticationDetailsHelper.GetAuthenticationDetails(executionContext, streamModel.ConnectorProviderDefinitionId.Value);
                 var schema = config.GetSchema();
                 await using var connectionAndTransaction = await _client.BeginTransaction(config.Authentication);
                 var transaction = connectionAndTransaction.Transaction;
 
                 var mainTableName = TableNameUtility.GetMainTableName(streamModel, schema);
-                var oldEdgeLocalTableName = $"{mainTableName.LocalName}Edges";
-                var newEdgeLocalTableName = $"{mainTableName.LocalName}_{DateTimeOffset.UtcNow}Edges";
 
-                var oldEdgeTableName = SqlName.FromUnsafe(oldEdgeLocalTableName).ToTableName(schema);
-                var newEdgeTableName = SqlName.FromUnsafe(newEdgeLocalTableName).ToTableName(schema);
+                // Archive old edge table name, since rename logic used during normal archive expect different name
+                {
+                    var oldEdgeLocalTableName = $"{mainTableName.LocalName}Edges";
+                    var newEdgeLocalTableName = $"{mainTableName.LocalName}_{DateTimeOffset.UtcNow}Edges";
 
-                var tableRenameText = $"""
-                    IF (OBJECT_ID(N'{oldEdgeTableName.FullyQualifiedName}') IS NOT NULL)
-                    BEGIN
-                        EXEC sp_rename N'{oldEdgeTableName.FullyQualifiedName}', {newEdgeTableName.LocalName};
-                    END
-                    """;
+                    var oldEdgeTableName = SqlName.FromUnsafe(oldEdgeLocalTableName).ToTableName(schema);
+                    var newEdgeTableName = SqlName.FromUnsafe(newEdgeLocalTableName).ToTableName(schema);
 
-                var sqlConnectorCommand = new SqlServerConnectorCommand() { Text = tableRenameText, Parameters = Array.Empty<SqlParameter>() };
-                await sqlConnectorCommand.ToSqlCommand(transaction).ExecuteScalarAsync();
+                    var tableRenameText = $"""
+                        IF (OBJECT_ID(N'{oldEdgeTableName.FullyQualifiedName}') IS NOT NULL)
+                        BEGIN
+                            EXEC sp_rename N'{oldEdgeTableName.FullyQualifiedName}', {newEdgeTableName.LocalName};
+                        END
+                        """;
+
+                    var renameSqlConnectorCommand = new SqlServerConnectorCommand() { Text = tableRenameText, Parameters = Array.Empty<SqlParameter>() };
+                    await renameSqlConnectorCommand
+                        .ToSqlCommand(transaction)
+                        .ExecuteScalarAsync();
+                }
+
+                // Check if old main table is present
+                {
+                    var tableColumnsSelectText = $"""
+                        SELECT columns.name FROM sys.columns columns
+                        INNER JOIN sys.tables tables
+                        ON tables.object_id = columns.object_id AND 
+                           tables.Name = '{mainTableName.LocalName}' AND
+                           tables.type = 'U'
+                        """;
+
+                    var tableCheckSqlConnectorCommand = new SqlServerConnectorCommand() { Text = tableColumnsSelectText, Parameters = Array.Empty<SqlParameter>() };
+                    var reader = await tableCheckSqlConnectorCommand
+                        .ToSqlCommand(transaction)
+                        .ExecuteReaderAsync();
+
+                    var existingColumns = new List<string>();
+                    while (await reader.ReadAsync())
+                    {
+                        existingColumns.Add(reader[0].ToString());
+                    }
+
+                    var expectedColumnNames = MainTableDefinition
+                        .GetColumnDefinitions(StreamMode.Sync, Array.Empty<(string, ConnectorPropertyDataType)>())
+                        .Select(columnDefinition => columnDefinition.Name);
+
+                    var existingColumnsContainsAllExpectedColumns = expectedColumnNames.All(column => existingColumns.Contains(column));
+
+                    if (!existingColumnsContainsAllExpectedColumns)
+                    {
+                        throw IncompatibleTableException.OldTableVersionExists(streamModel.Id, (Guid)streamModel.ConnectorProviderDefinitionId);
+                    }
+                }
 
                 await transaction.CommitAsync();
             });

--- a/src/Connector.SqlServer/Connector/SqlServerConnector.cs
+++ b/src/Connector.SqlServer/Connector/SqlServerConnector.cs
@@ -41,12 +41,8 @@ namespace CluedIn.Connector.SqlServer.Connector
 
         public override async Task VerifyExistingContainer(ExecutionContext executionContext, IReadOnlyStreamModel streamModel)
         {
-            Debugger.Launch();
-
             await ExecuteWithRetryAsync(async () =>
             {
-                this._logger.LogError("Verifying existing container for stream: {streamId}", streamModel.Id);
-
                 var config = await AuthenticationDetailsHelper.GetAuthenticationDetails(executionContext, streamModel.ConnectorProviderDefinitionId.Value);
                 var schema = config.GetSchema();
                 await using var connectionAndTransaction = await _client.BeginTransaction(config.Authentication);

--- a/src/Connector.SqlServer/Exceptions/IncompatibleTableException.cs
+++ b/src/Connector.SqlServer/Exceptions/IncompatibleTableException.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+namespace CluedIn.Connector.SqlServer.Exceptions
+{
+    internal class IncompatibleTableException : Exception
+    {
+        public IncompatibleTableException(string message)
+            : base($"Table is incompatible: {message}")
+        {
+
+        }
+
+        public static IncompatibleTableException OldTableVersionExists(Guid streamId, Guid connectorProviderDefinitionId)
+        {
+            var message = $"""
+
+                StreamId: {streamId}
+                ConnectorProviderDefinitionId: {connectorProviderDefinitionId}
+
+                It looks like the tables in the database is not compatible with this version of the connector.
+                This is most likely because the tables were created in an older version of the connector.
+                To remedy:
+                    - Disable all streams using this connector
+                    - Reprocess the streams
+                    - Reenable the streams
+                """;
+
+            return new IncompatibleTableException(message);
+        }
+    }
+}


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#21250](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/21250)

Throw "nice" exception when old table exists, so that it's easier to identify upgrade needs to happen.
![image](https://github.com/CluedIn-io/CluedIn.Connector.SqlServer/assets/39338793/7fbe258f-c287-4e08-a2ef-27b29582d6e5)


## Test approach <!-- Remove if not needed -->
Setup old version of connector, and create stream. Switch to new connector, and observe that exception is thrown.