### PR TITLE
chore: Simplify passing of timestamp

### DIFF
--- a/src/Connector.SqlServer/Connector/SqlServerConnector.cs
+++ b/src/Connector.SqlServer/Connector/SqlServerConnector.cs
@@ -78,16 +78,16 @@ namespace CluedIn.Connector.SqlServer.Connector
                 var schema = config.GetSchema();
                 await using var connectionAndTransaction = await _client.BeginTransaction(config.Authentication);
                 var transaction = connectionAndTransaction.Transaction;
-                var timeStamp = DateTimeOffset.UtcNow;
+                var timestamp = DateTimeOffset.UtcNow;
 
-                var sqlConnectorEntityData = new SqlConnectorEntityData(connectorEntityData, Guid.NewGuid());
+                var sqlConnectorEntityData = new SqlConnectorEntityData(connectorEntityData, Guid.NewGuid(), timestamp);
 
                 if (connectorEntityData.ChangeType == VersionChangeType.Removed)
                 {
                     switch (streamModel.Mode)
                     {
                         case StreamMode.EventStream:
-                            result = await ExecuteUpsert(streamModel, sqlConnectorEntityData, timeStamp, schema, transaction);
+                            result = await ExecuteUpsert(streamModel, sqlConnectorEntityData, schema, transaction);
                             break;
 
                         case StreamMode.Sync:
@@ -109,7 +109,7 @@ namespace CluedIn.Connector.SqlServer.Connector
                 {
                     case ExistenceCommandUtility.ExistenceCheckResult.NoVersionExists:
                     case ExistenceCommandUtility.ExistenceCheckResult.EarlierVersionExists:
-                        var upsertResult = await ExecuteUpsert(streamModel, sqlConnectorEntityData, timeStamp, schema, transaction);
+                        var upsertResult = await ExecuteUpsert(streamModel, sqlConnectorEntityData, schema, transaction);
                         result = upsertResult;
 
                         break;
@@ -160,11 +160,11 @@ namespace CluedIn.Connector.SqlServer.Connector
             return SaveResult.Success;
         }
 
-        private async Task<SaveResult> ExecuteUpsert(IReadOnlyStreamModel streamModel, SqlConnectorEntityData sqlConnectorEntityData, DateTimeOffset timeStamp, SqlName schema, SqlTransaction transaction)
+        private async Task<SaveResult> ExecuteUpsert(IReadOnlyStreamModel streamModel, SqlConnectorEntityData sqlConnectorEntityData, SqlName schema, SqlTransaction transaction)
         {
             var isSyncMode = streamModel.Mode == StreamMode.Sync;
 
-            var updateCommand = StoreCommandBuilder.MainTableCommand(streamModel, sqlConnectorEntityData, timeStamp, schema);
+            var updateCommand = StoreCommandBuilder.MainTableCommand(streamModel, sqlConnectorEntityData, schema);
             var updateSqlCommand = updateCommand.ToSqlCommand(transaction);
             await updateSqlCommand.ExecuteNonQueryAsync();
 

--- a/src/Connector.SqlServer/Utils/MainTableColumnDefinition.cs
+++ b/src/Connector.SqlServer/Utils/MainTableColumnDefinition.cs
@@ -6,7 +6,7 @@ namespace CluedIn.Connector.SqlServer.Utils
     internal record MainTableColumnDefinition(
         string Name,
         ConnectorSqlType ConnectorSqlType,
-        Func<(SqlConnectorEntityData data, DateTimeOffset timeStamp), object> GetValueFunc,
+        Func<SqlConnectorEntityData, object> GetValueFunc,
         bool CanBeNull = false,
         bool IsPrimaryKey = false,
         bool AddIndex = false

--- a/src/Connector.SqlServer/Utils/SqlConnectorEntityData.cs
+++ b/src/Connector.SqlServer/Utils/SqlConnectorEntityData.cs
@@ -25,10 +25,13 @@ namespace CluedIn.Connector.SqlServer.Utils
 
         public Guid? CorrelationId;
 
-        public SqlConnectorEntityData(IReadOnlyConnectorEntityData inner, Guid? correlationId)
+        public DateTimeOffset Timestamp;
+
+        public SqlConnectorEntityData(IReadOnlyConnectorEntityData inner, Guid? correlationId, DateTimeOffset timestamp)
         {
             _inner = inner;
             CorrelationId = correlationId;
+            Timestamp = timestamp;
         }
     }
 }

--- a/src/Connector.SqlServer/Utils/StoreCommandBuilder.cs
+++ b/src/Connector.SqlServer/Utils/StoreCommandBuilder.cs
@@ -9,9 +9,9 @@ namespace CluedIn.Connector.SqlServer.Utils
 {
     internal static class StoreCommandBuilder
     {
-        public static SqlServerConnectorCommand MainTableCommand(IReadOnlyStreamModel streamModel, SqlConnectorEntityData connectorEntityData, DateTimeOffset timeStamp, SqlName schema)
+        public static SqlServerConnectorCommand MainTableCommand(IReadOnlyStreamModel streamModel, SqlConnectorEntityData connectorEntityData, SqlName schema)
         {
-            return MainTableDefinition.CreateUpsertCommand(streamModel, connectorEntityData, timeStamp, schema);
+            return MainTableDefinition.CreateUpsertCommand(streamModel, connectorEntityData, schema);
         }
 
         public static SqlServerConnectorCommand CodesInsertCommand(IReadOnlyStreamModel streamModel, SqlConnectorEntityData connectorEntityData, SqlName schema)

--- a/src/Connector.SqlServer/Utils/TableDefinitions/MainTableDefinition.cs
+++ b/src/Connector.SqlServer/Utils/TableDefinitions/MainTableDefinition.cs
@@ -27,23 +27,23 @@ namespace CluedIn.Connector.SqlServer.Utils.TableDefinitions
             {
                 StreamMode.EventStream => new MainTableColumnDefinition[]
                 {
-                    new("Id", SqlColumnHelper.UniqueIdentifier, input => input.data.EntityId, IsPrimaryKey: true),
-                    new("PersistVersion", SqlColumnHelper.Int, input => input.data.PersistInfo != null ? (object)input.data.PersistInfo.PersistVersion : (object)DBNull.Value, CanBeNull: true),
-                    new("PersistHash", SqlColumnHelper.Char24, input => input.data.PersistInfo != null ? (object)input.data.PersistInfo.PersistHash : (object)DBNull.Value, CanBeNull: true),
-                    new("OriginEntityCode", SqlColumnHelper.NVarchar1024, input => input.data.OriginEntityCode != null ? (object)input.data.OriginEntityCode.ToString() : (object)DBNull.Value, CanBeNull: true),
-                    new("EntityType", SqlColumnHelper.NVarcharMax, input => input.data.EntityType != null ? (object)input.data.EntityType.ToString() : (object)DBNull.Value, CanBeNull: true),
-                    new("TimeStamp", SqlColumnHelper.DateTimeOffset7, input => input.timeStamp),
-                    new("ChangeType", SqlColumnHelper.Int, input => input.data.ChangeType),
-                    new("CorrelationId", SqlColumnHelper.UniqueIdentifier, input => input.data.CorrelationId, IsPrimaryKey: true)
+                    new("Id", SqlColumnHelper.UniqueIdentifier, input => input.EntityId, IsPrimaryKey: true),
+                    new("PersistVersion", SqlColumnHelper.Int, input => input.PersistInfo != null ? (object)input.PersistInfo.PersistVersion : (object)DBNull.Value, CanBeNull: true),
+                    new("PersistHash", SqlColumnHelper.Char24, input => input.PersistInfo != null ? (object)input.PersistInfo.PersistHash : (object)DBNull.Value, CanBeNull: true),
+                    new("OriginEntityCode", SqlColumnHelper.NVarchar1024, input => input.OriginEntityCode != null ? (object)input.OriginEntityCode.ToString() : (object)DBNull.Value, CanBeNull: true),
+                    new("EntityType", SqlColumnHelper.NVarcharMax, input => input.EntityType != null ? (object)input.EntityType.ToString() : (object)DBNull.Value, CanBeNull: true),
+                    new("Timestamp", SqlColumnHelper.DateTimeOffset7, input => input.Timestamp),
+                    new("ChangeType", SqlColumnHelper.Int, input => input.ChangeType),
+                    new("CorrelationId", SqlColumnHelper.UniqueIdentifier, input => input.CorrelationId, IsPrimaryKey: true)
                 },
                 StreamMode.Sync => new MainTableColumnDefinition[]
                 {
-                    new("Id", SqlColumnHelper.UniqueIdentifier, input => input.data.EntityId, IsPrimaryKey: true),
-                    new("PersistVersion", SqlColumnHelper.Int, input => input.data.PersistInfo!.PersistVersion),
-                    new("PersistHash", SqlColumnHelper.Char24, input => input.data.PersistInfo!.PersistHash),
-                    new("OriginEntityCode", SqlColumnHelper.NVarchar1024, input => input.data.OriginEntityCode.ToString()),
-                    new("EntityType", SqlColumnHelper.NVarcharMax, input => input.data.EntityType.ToString()),
-                    new("TimeStamp", SqlColumnHelper.DateTimeOffset7, input => input.timeStamp),
+                    new("Id", SqlColumnHelper.UniqueIdentifier, input => input.EntityId, IsPrimaryKey: true),
+                    new("PersistVersion", SqlColumnHelper.Int, input => input.PersistInfo!.PersistVersion),
+                    new("PersistHash", SqlColumnHelper.Char24, input => input.PersistInfo!.PersistHash),
+                    new("OriginEntityCode", SqlColumnHelper.NVarchar1024, input => input.OriginEntityCode.ToString()),
+                    new("EntityType", SqlColumnHelper.NVarcharMax, input => input.EntityType.ToString()),
+                    new("Timestamp", SqlColumnHelper.DateTimeOffset7, input => input.Timestamp),
                 },
                 _ => throw new ArgumentOutOfRangeException(nameof(streamMode), streamMode, null)
             };
@@ -57,7 +57,7 @@ namespace CluedIn.Connector.SqlServer.Utils.TableDefinitions
                     sqlType,
                     input =>
                     {
-                        var propertyValue = input.data.Properties.First(x => x.Name == property.name).Value;
+                        var propertyValue = input.Properties.First(x => x.Name == property.name).Value;
                         if (propertyValue == null)
                         {
                             return DBNull.Value;
@@ -78,7 +78,7 @@ namespace CluedIn.Connector.SqlServer.Utils.TableDefinitions
             return allColumns;
         }
 
-        public static SqlServerConnectorCommand CreateUpsertCommand(IReadOnlyStreamModel streamModel, SqlConnectorEntityData connectorEntityData, DateTimeOffset timeStamp, SqlName schema)
+        public static SqlServerConnectorCommand CreateUpsertCommand(IReadOnlyStreamModel streamModel, SqlConnectorEntityData connectorEntityData, SqlName schema)
         {
             var mainTableName = TableNameUtility.GetMainTableName(streamModel, schema);
             var mainTableDefinitions = GetColumnDefinitions(connectorEntityData);
@@ -89,7 +89,7 @@ namespace CluedIn.Connector.SqlServer.Utils.TableDefinitions
             var valueParameters = mainTableDefinitions.Select(definition =>
                 new SqlParameter($"@{definition.Name}", definition.ConnectorSqlType.SqlType)
                 {
-                    Value = definition.GetValueFunc((connectorEntityData, timeStamp))
+                    Value = definition.GetValueFunc(connectorEntityData)
                 })
                 .ToArray();
 


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#23472](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/23472)

Include timestamp in `SqlConnectorEntityData`, to simplify passing