### PR TITLE
fix: Rework `VerifyExistingContainer`, to log exception if table is incompatible

### DIFF
--- a/src/Connector.SqlServer/Connector/SqlServerConnector.cs
+++ b/src/Connector.SqlServer/Connector/SqlServerConnector.cs
@@ -119,7 +119,12 @@ namespace CluedIn.Connector.SqlServer.Connector
 
                         if (!existingColumnsContainsAllExpectedColumns)
                         {
-                            throw IncompatibleTableException.OldTableVersionExists(streamModel.Id, (Guid)streamModel.ConnectorProviderDefinitionId);
+                            // If an exception is thrown during `VerifyExistingContainer`, nothing can be done with the stream.
+                            // This includes reprocessing the stream, to create new tables.
+                            // Until this is changed in platform, we simply log the exception instead of throwing
+                            // PBI: #23500
+                            var exception = IncompatibleTableException.OldTableVersionExists(streamModel.Id, (Guid)streamModel.ConnectorProviderDefinitionId);
+                            _logger.LogError(exception, "Not all expected columns were present, most likely because the table was created in an old version");
                         }
                     }
                 }

--- a/src/Connector.SqlServer/Connector/SqlServerConnector.cs
+++ b/src/Connector.SqlServer/Connector/SqlServerConnector.cs
@@ -73,7 +73,26 @@ namespace CluedIn.Connector.SqlServer.Connector
 
                 // Check if old main table is present
                 {
-                    var tableColumnsSelectText = $"""
+                    var tableExistsText = $"""
+                        IF (OBJECT_ID(N'{mainTableName.FullyQualifiedName}') IS NOT NULL)
+                        BEGIN
+                        	SELECT 1
+                        END
+                        ELSE
+                        BEGIN
+                        	SELECT 0
+                        END
+                        """;
+
+                    var tableExistsCommand = new SqlServerConnectorCommand() { Text = tableExistsText, Parameters = Array.Empty<SqlParameter>() };
+                    var tableExistsResult = await tableExistsCommand.ToSqlCommand(transaction).ExecuteScalarAsync();
+
+                    // If the table exists, we need to check if it was created in an older version of the connector.
+                    // The way we do this is check is to check if it contains all of the columns that we expect the
+                    // main table to have in this version.
+                    if ((int)tableExistsResult == 1)
+                    {
+                        var tableColumnsSelectText = $"""
                         SELECT columns.name FROM sys.columns columns
                         INNER JOIN sys.tables tables
                         ON tables.object_id = columns.object_id AND 
@@ -81,26 +100,27 @@ namespace CluedIn.Connector.SqlServer.Connector
                            tables.type = 'U'
                         """;
 
-                    var tableCheckSqlConnectorCommand = new SqlServerConnectorCommand() { Text = tableColumnsSelectText, Parameters = Array.Empty<SqlParameter>() };
-                    var reader = await tableCheckSqlConnectorCommand
-                        .ToSqlCommand(transaction)
-                        .ExecuteReaderAsync();
+                        var tableCheckSqlConnectorCommand = new SqlServerConnectorCommand() { Text = tableColumnsSelectText, Parameters = Array.Empty<SqlParameter>() };
+                        var reader = await tableCheckSqlConnectorCommand
+                            .ToSqlCommand(transaction)
+                            .ExecuteReaderAsync();
 
-                    var existingColumns = new List<string>();
-                    while (await reader.ReadAsync())
-                    {
-                        existingColumns.Add(reader[0].ToString());
-                    }
+                        var existingColumns = new List<string>();
+                        while (await reader.ReadAsync())
+                        {
+                            existingColumns.Add(reader[0].ToString());
+                        }
 
-                    var expectedColumnNames = MainTableDefinition
-                        .GetColumnDefinitions(StreamMode.Sync, Array.Empty<(string, ConnectorPropertyDataType)>())
-                        .Select(columnDefinition => columnDefinition.Name);
+                        var expectedColumnNames = MainTableDefinition
+                            .GetColumnDefinitions(StreamMode.Sync, Array.Empty<(string, ConnectorPropertyDataType)>())
+                            .Select(columnDefinition => columnDefinition.Name);
 
-                    var existingColumnsContainsAllExpectedColumns = expectedColumnNames.All(column => existingColumns.Contains(column));
+                        var existingColumnsContainsAllExpectedColumns = expectedColumnNames.All(column => existingColumns.Contains(column));
 
-                    if (!existingColumnsContainsAllExpectedColumns)
-                    {
-                        throw IncompatibleTableException.OldTableVersionExists(streamModel.Id, (Guid)streamModel.ConnectorProviderDefinitionId);
+                        if (!existingColumnsContainsAllExpectedColumns)
+                        {
+                            throw IncompatibleTableException.OldTableVersionExists(streamModel.Id, (Guid)streamModel.ConnectorProviderDefinitionId);
+                        }
                     }
                 }
 


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#21250](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/21250)

Check if table is present, before doing check of columns.
Log exception instead of throwing, since throwing exception will lock user out of doing anything with the connector.

Exception that is logged:
```
Not all expected columns were present, most likely because the table was created in an old version
CluedIn.Connector.SqlServer.Exceptions.IncompatibleTableException: Table is incompatible:
StreamId: 0e63668d-0bde-4394-b204-85f98fc16e4d
ConnectorProviderDefinitionId: 81314218-1f77-48fe-95c2-d9fb7120519d

It looks like the tables in the database is not compatible with this version of the connector.
This is most likely because the tables were created in an older version of the connector.
To remedy:
    - Disable all streams using this connector
    - Reprocess the streams
    - Reenable the streams
```
