### PR TITLE
fix: Add index on entity id in edge tables

### DIFF
--- a/src/Connector.SqlServer/Utils/TableDefinitions/EdgeTableDefinition.cs
+++ b/src/Connector.SqlServer/Utils/TableDefinitions/EdgeTableDefinition.cs
@@ -47,7 +47,7 @@ namespace CluedIn.Connector.SqlServer.Utils.TableDefinitions
                     return new ColumnDefinition[]
                     {
                         new("Id", SqlColumnHelper.UniqueIdentifier, IsPrimaryKey: true),
-                        new("EntityId", SqlColumnHelper.UniqueIdentifier),
+                        new("EntityId", SqlColumnHelper.UniqueIdentifier, AddIndex: true),
                         new("EdgeType", SqlColumnHelper.NVarchar1024),
                         new(codeColumnName, SqlColumnHelper.NVarchar1024),
                         new("ChangeType", SqlColumnHelper.Int),
@@ -58,7 +58,7 @@ namespace CluedIn.Connector.SqlServer.Utils.TableDefinitions
                     return new ColumnDefinition[]
                     {
                         new("Id", SqlColumnHelper.UniqueIdentifier, IsPrimaryKey: true),
-                        new("EntityId", SqlColumnHelper.UniqueIdentifier),
+                        new("EntityId", SqlColumnHelper.UniqueIdentifier, AddIndex: true),
                         new("EdgeType", SqlColumnHelper.NVarcharMax),
                         new(codeColumnName, SqlColumnHelper.NVarchar1024),
                     };


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#23497](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/23497)

During testing on Platform staging, deadlocks was occurring. This was due to an unnecessary table scan that was happening in the insert of edges.
Old query plan:
![image](https://github.com/CluedIn-io/CluedIn.Connector.SqlServer/assets/39338793/9a640fe9-4f55-4f6e-961b-bcbfd8447d4f)
New query plan:
![image](https://github.com/CluedIn-io/CluedIn.Connector.SqlServer/assets/39338793/1564e94a-09ea-41dd-9c62-78d51bc97224)

Note: The tables scans that are present in the new query plan, all happen on the custom table typed variables, ie. the tables that are passed as parameters. They should therefore be small and won't have contention with other queries.

## Test approach <!-- Remove if not needed -->
Create new stream, exporting incoming and or outgoing edges, and observe that index is added.
In order to performance test, you need to have a sufficiently large dataset (in platform staging, 200K, but smaller will likely suffice), and stream it all at once. Without this index, you will see deadlocks happening, and a very low throughput. With this fix, there are no deadlocks, and you should observer a much larger throughput.