### PR TITLE
fix: Filter out default columns from properties

### DIFF
--- a/test/unit/Connector.SqlServer.Test/Utils/TableDefinitions/MainTableDefinitionTests.cs
+++ b/test/unit/Connector.SqlServer.Test/Utils/TableDefinitions/MainTableDefinitionTests.cs
@@ -7,6 +7,7 @@ using FluentAssertions;
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Linq;
 using Xunit;
 
 namespace CluedIn.Connector.SqlServer.Unit.Tests.Utils.TableDefinitions
@@ -47,6 +48,24 @@ namespace CluedIn.Connector.SqlServer.Unit.Tests.Utils.TableDefinitions
             // assert
             eventColumnDefinitions.Should().Contain(column => column.Name == "ChangeType");
             eventColumnDefinitions.Should().Contain(column => column.Name == "CorrelationId");
+        }
+
+        [Theory, AutoNData]
+        public void GetColumnDefinitions_ShouldNotIncludePropertiesMultipleTimes()
+        {
+            // arrange
+            var properties = new (string, ConnectorPropertyDataType)[]
+            {
+                ("PersistVersion", new EntityPropertyConnectorPropertyDataType(typeof(string))),
+            };
+
+            // act
+            var syncColumnDefinitions = MainTableDefinition.GetColumnDefinitions(StreamMode.Sync, properties);
+            var eventColumnDefinitions = MainTableDefinition.GetColumnDefinitions(StreamMode.EventStream, properties);
+
+            // assert
+            syncColumnDefinitions.Should().ContainSingle(column => column.Name == "PersistVersion");
+            eventColumnDefinitions.Should().ContainSingle(column => column.Name == "PersistVersion");
         }
     }
 }


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#23548](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/23548)

Filter out default properties from properties that have been selected to be exported. This is so that we don't have the same column twice. Example of property that can be selected to be exported, but is in default columns is `PersistVersion`

## Test approach <!-- Remove if not needed -->
Run unit test