### PR TITLE
chore: Use simpler command for syncing edge data, when none is present

### DIFF
--- a/src/Connector.SqlServer/Utils/TableDefinitions/EdgeTableDefinition.cs
+++ b/src/Connector.SqlServer/Utils/TableDefinitions/EdgeTableDefinition.cs
@@ -165,6 +165,21 @@ namespace CluedIn.Connector.SqlServer.Utils.TableDefinitions
             var edgeTableName = TableNameUtility.GetEdgesTableName(streamModel, direction, schema);
             var edgeTableType = CreateCustomTypeCommandUtility.GetEdgeTableCustomTypeName(streamModel, direction, schema);
 
+            var sqlRecords = GetSqlRecords(StreamMode.Sync, direction, connectorEntityData);
+            var entityIdParameter = new SqlParameter("@EntityId", SqlDbType.UniqueIdentifier) { Value = connectorEntityData.EntityId };
+
+            if (!sqlRecords.Any())
+            {
+                // If there are edges to be exported, we can use a simpler command,
+                // than if we have to potentially both delete and insert edges.
+                var simpleCommandText = $"""
+                    DELETE {edgeTableName.FullyQualifiedName}
+                    WHERE [EntityId] = @EntityId
+                    """;
+
+                return new SqlServerConnectorCommand { Text = simpleCommandText, Parameters = new[] { entityIdParameter } };
+            }
+
             var codeColumnName = direction == EdgeDirection.Outgoing
                 ? "ToCode"
                 : "FromCode";
@@ -198,13 +213,6 @@ namespace CluedIn.Connector.SqlServer.Utils.TableDefinitions
                 WHERE existingValues.[Id] IS NULL
                 """;
 
-            var sqlRecords = GetSqlRecords(StreamMode.Sync, direction, connectorEntityData);
-            if (!sqlRecords.Any())
-            {
-                sqlRecords = null;
-            }
-
-            var entityIdParameter = new SqlParameter("@EntityId", SqlDbType.UniqueIdentifier) { Value = connectorEntityData.EntityId };
             var recordsParameter = new SqlParameter($"@{edgeTableType.LocalName}", SqlDbType.Structured) { Value = sqlRecords, TypeName = edgeTableType.FullyQualifiedName };
 
             return new SqlServerConnectorCommand { Text = commandText, Parameters = new[] { entityIdParameter, recordsParameter } };


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#23551](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/23551)

If no edges are present, we can simplify the command that we run to upsert in sync mode.
Simply, we delete all rows, that have the `EntityId` of the entity we're currently syncing.

## Test approach <!-- Remove if not needed -->
Manually tested.