### PR TITLE
fix: Set correct column types in event mode

### DIFF
--- a/src/Connector.SqlServer/Utils/TableDefinitions/CodeTableDefinition.cs
+++ b/src/Connector.SqlServer/Utils/TableDefinitions/CodeTableDefinition.cs
@@ -20,8 +20,8 @@ namespace CluedIn.Connector.SqlServer.Utils.TableDefinitions
                     {
                         new("EntityId", SqlColumnHelper.UniqueIdentifier, AddIndex: true),
                         new("Code", SqlColumnHelper.NVarchar1024),
-                        new("ChangeType", SqlColumnHelper.NVarchar256),
-                        new("CorrelationId", SqlColumnHelper.Int)
+                        new("ChangeType", SqlColumnHelper.Int),
+                        new("CorrelationId", SqlColumnHelper.UniqueIdentifier)
                     };
 
                 case StreamMode.Sync:
@@ -50,8 +50,8 @@ namespace CluedIn.Connector.SqlServer.Utils.TableDefinitions
                         var record = new SqlDataRecord(sqlMetaData);
                         record.SetGuid(0, connectorEntityData.EntityId);
                         record.SetString(1, code.Key);
-                        record.SetString(2, connectorEntityData.ChangeType.ToString());
-                        record.SetGuid(3, connectorEntityData.CorrelationId.Value);
+                        record.SetInt32(2, (int)connectorEntityData.ChangeType);
+                        record.SetGuid(3, (Guid)connectorEntityData.CorrelationId.Value);
                         return record;
                     });
 

--- a/src/Connector.SqlServer/Utils/TableDefinitions/EdgePropertiesTableDefinition.cs
+++ b/src/Connector.SqlServer/Utils/TableDefinitions/EdgePropertiesTableDefinition.cs
@@ -59,7 +59,7 @@ namespace CluedIn.Connector.SqlServer.Utils.TableDefinitions
                                 record.SetGuid(0, edgeId);
                                 record.SetString(1, property.Key);
                                 record.SetString(2, property.Value);
-                                record.SetString(3, connectorEntityData.ChangeType.ToString());
+                                record.SetInt32(3, (int)connectorEntityData.ChangeType);
                                 record.SetGuid(4, connectorEntityData.CorrelationId.Value);
 
                                 return record;

--- a/src/Connector.SqlServer/Utils/TableDefinitions/EdgeTableDefinition.cs
+++ b/src/Connector.SqlServer/Utils/TableDefinitions/EdgeTableDefinition.cs
@@ -93,7 +93,7 @@ namespace CluedIn.Connector.SqlServer.Utils.TableDefinitions
                         record.SetGuid(1, connectorEntityData.EntityId);
                         record.SetString(2, edge.EdgeType);
                         record.SetString(3, code.Key);
-                        record.SetString(4, connectorEntityData.ChangeType.ToString());
+                        record.SetInt32(4, (int)connectorEntityData.ChangeType);
                         record.SetGuid(5, connectorEntityData.CorrelationId.Value);
                         return record;
                     });

--- a/test/unit/Connector.SqlServer.Test/Utils/TableDefinitions/CodeTableDefinitionTests.cs
+++ b/test/unit/Connector.SqlServer.Test/Utils/TableDefinitions/CodeTableDefinitionTests.cs
@@ -1,7 +1,13 @@
 ﻿using CluedIn.Connector.SqlServer.Unit.Tests.Customizations;
+using CluedIn.Connector.SqlServer.Utils;
 using CluedIn.Connector.SqlServer.Utils.TableDefinitions;
+using CluedIn.Core.Connectors;
+using CluedIn.Core.Data;
+using CluedIn.Core.Data.Parts;
 using CluedIn.Core.Streams.Models;
 using FluentAssertions;
+using System;
+using System.Linq;
 using Xunit;
 
 namespace CluedIn.Connector.SqlServer.Unit.Tests.Utils.TableDefinitions
@@ -18,6 +24,80 @@ namespace CluedIn.Connector.SqlServer.Unit.Tests.Utils.TableDefinitions
             // assert
             eventColumnDefinitions.Should().Contain(column => column.Name == "ChangeType");
             eventColumnDefinitions.Should().Contain(column => column.Name == "CorrelationId");
+        }
+
+        [Theory, AutoNData]
+        public void GetSqlRecord_ShouldYieldCorrectRecords_ForEventMode(Guid entityId, EntityCode originEntityCode, EntityType entityType, EntityCode[] codes, Guid correlationId, DateTimeOffset timestamp)
+        {
+            // arrange
+            var connectorEntityData = new ConnectorEntityData(
+                VersionChangeType.Added,
+                StreamMode.EventStream,
+                entityId,
+                persistInfo: null,
+                previousPersistInfo: null,
+                originEntityCode,
+                entityType,
+                properties: Array.Empty<ConnectorPropertyData>(),
+                codes,
+                incomingEdges: Array.Empty<EntityEdge>(),
+                outgoingEdges: Array.Empty<EntityEdge>());
+
+            var sqlConnectorEntityData = new SqlConnectorEntityData(connectorEntityData, correlationId, timestamp);
+
+            // act
+            var sqlRecords = CodeTableDefinition.GetSqlRecords(StreamMode.EventStream, sqlConnectorEntityData).ToArray();
+
+            // assert
+            sqlRecords.Should().NotBeEmpty();
+            sqlRecords.Should().HaveCount(codes.Length);
+
+            for (var i = 0; i < codes.Length; i++)
+            {
+                var sqlRecord = sqlRecords[i];
+                var code = codes[i];
+
+                sqlRecord[0].Should().Be(entityId);
+                sqlRecord[1].Should().Be(code.Key);
+                sqlRecord[2].Should().Be(VersionChangeType.Added);
+                sqlRecord[3].Should().Be(correlationId);
+            }
+        }
+
+        [Theory, AutoNData]
+        public void GetSqlRecord_ShouldYieldCorrectRecords_ForSyncMode(Guid entityId, EntityCode originEntityCode, EntityType entityType, EntityCode[] codes, Guid correlationId, DateTimeOffset timestamp)
+        {
+            // arrange
+            var connectorEntityData = new ConnectorEntityData(
+                VersionChangeType.Added,
+                StreamMode.Sync,
+                entityId,
+                persistInfo: null,
+                previousPersistInfo: null,
+                originEntityCode,
+                entityType,
+                properties: Array.Empty<ConnectorPropertyData>(),
+                codes,
+                incomingEdges: Array.Empty<EntityEdge>(),
+                outgoingEdges: Array.Empty<EntityEdge>());
+
+            var sqlConnectorEntityData = new SqlConnectorEntityData(connectorEntityData, correlationId, timestamp);
+
+            // act
+            var sqlRecords = CodeTableDefinition.GetSqlRecords(StreamMode.Sync, sqlConnectorEntityData).ToArray();
+
+            // assert
+            sqlRecords.Should().NotBeEmpty();
+            sqlRecords.Should().HaveCount(codes.Length);
+
+            for (var i = 0; i < codes.Length; i++)
+            {
+                var sqlRecord = sqlRecords[i];
+                var code = codes[i];
+
+                sqlRecord[0].Should().Be(entityId);
+                sqlRecord[1].Should().Be(code.Key);
+            }
         }
     }
 }

--- a/test/unit/Connector.SqlServer.Test/Utils/TableDefinitions/EdgePropertiesTableDefinitionTests.cs
+++ b/test/unit/Connector.SqlServer.Test/Utils/TableDefinitions/EdgePropertiesTableDefinitionTests.cs
@@ -4,6 +4,11 @@ using CluedIn.Connector.SqlServer.Utils;
 using CluedIn.Core.Streams.Models;
 using FluentAssertions;
 using Xunit;
+using CluedIn.Core.Connectors;
+using CluedIn.Core.Data.Parts;
+using CluedIn.Core.Data;
+using System.Linq;
+using System;
 
 namespace CluedIn.Connector.SqlServer.Unit.Tests.Utils.TableDefinitions
 {
@@ -23,6 +28,112 @@ namespace CluedIn.Connector.SqlServer.Unit.Tests.Utils.TableDefinitions
 
             eventColumnDefinitionsIncoming.Should().Contain(column => column.Name == "ChangeType");
             eventColumnDefinitionsIncoming.Should().Contain(column => column.Name == "CorrelationId");
+        }
+
+        [Theory, AutoNData]
+        public void GetSqlRecord_ShouldYieldCorrectRecords_ForEventMode(Guid entityId, EntityCode originEntityCode, EntityReference[] outgoingEdgeReferences, Guid correlationId, DateTimeOffset timestamp)
+        {
+            // arrange
+            var entityType = EntityType.Person;
+            var fromReference = new EntityReference(entityType, "fromReferenceName");
+            var outgoingEdges = outgoingEdgeReferences
+                .Select((toReference, i) =>
+                {
+                    var edge = new EntityEdge(fromReference, toReference, EntityEdgeType.For);
+                    edge.Properties.Add(i.ToString(), i.ToString());
+                    return edge;
+                })
+                .ToArray();
+
+            var connectorEntityData = new ConnectorEntityData(
+                VersionChangeType.Added,
+                StreamMode.EventStream,
+                entityId,
+                persistInfo: null,
+                previousPersistInfo: null,
+                originEntityCode,
+                entityType,
+                properties: Array.Empty<ConnectorPropertyData>(),
+                entityCodes: Array.Empty<IEntityCode>(),
+                incomingEdges: Array.Empty<EntityEdge>(),
+                outgoingEdges: outgoingEdges);
+
+            var sqlConnectorEntityData = new SqlConnectorEntityData(connectorEntityData, correlationId, timestamp);
+
+            // act
+            var sqlRecords = EdgePropertiesTableDefinition.GetSqlDataRecords(StreamMode.EventStream, sqlConnectorEntityData, EdgeDirection.Outgoing).ToArray();
+
+            // assert
+            sqlRecords.Should().NotBeEmpty();
+            sqlRecords.Should().HaveCount(outgoingEdges.SelectMany(edge => edge.Properties).Count());
+
+            for (var i = 0; i < outgoingEdges.Length; i++)
+            {
+                var sqlRecord = sqlRecords[i];
+                var edge = outgoingEdges[i];
+                var edgeId = EdgeTableDefinition.GetEdgeId(entityId, edge, EdgeDirection.Outgoing);
+
+                foreach (var edgeProperty in edge.Properties)
+                {
+                    sqlRecord[0].Should().Be(edgeId);
+                    sqlRecord[1].Should().Be(edgeProperty.Key);
+                    sqlRecord[2].Should().Be(edgeProperty.Value);
+                    sqlRecord[3].Should().Be(VersionChangeType.Added);
+                    sqlRecord[4].Should().Be(correlationId);
+                }
+            }
+        }
+
+        [Theory, AutoNData]
+        public void GetSqlRecord_ShouldYieldCorrectRecords_ForSyncMode(Guid entityId, EntityCode originEntityCode, EntityReference[] outgoingEdgeReferences, Guid correlationId, DateTimeOffset timestamp)
+        {
+            // arrange
+            var entityType = EntityType.Person;
+            var fromReference = new EntityReference(entityType, "fromReferenceName");
+            var outgoingEdges = outgoingEdgeReferences
+                .Select((toReference, i) =>
+                {
+                    var edge = new EntityEdge(fromReference, toReference, EntityEdgeType.For);
+                    edge.Properties.Add(i.ToString(), i.ToString());
+                    return edge;
+                })
+                .ToArray();
+
+            var connectorEntityData = new ConnectorEntityData(
+                VersionChangeType.Added,
+                StreamMode.EventStream,
+                entityId,
+                persistInfo: null,
+                previousPersistInfo: null,
+                originEntityCode,
+                entityType,
+                properties: Array.Empty<ConnectorPropertyData>(),
+                entityCodes: Array.Empty<IEntityCode>(),
+                incomingEdges: Array.Empty<EntityEdge>(),
+                outgoingEdges: outgoingEdges);
+
+            var sqlConnectorEntityData = new SqlConnectorEntityData(connectorEntityData, correlationId, timestamp);
+
+            // act
+            var sqlRecords = EdgePropertiesTableDefinition.GetSqlDataRecords(StreamMode.Sync, sqlConnectorEntityData, EdgeDirection.Outgoing).ToArray();
+
+            // assert
+            sqlRecords.Should().NotBeEmpty();
+            sqlRecords.Should().HaveCount(outgoingEdges.SelectMany(edge => edge.Properties).Count());
+
+            for (var i = 0; i < outgoingEdges.Length; i++)
+            {
+                var sqlRecord = sqlRecords[i];
+                var edge = outgoingEdges[i];
+                var edgeId = EdgeTableDefinition.GetEdgeId(entityId, edge, EdgeDirection.Outgoing);
+
+                foreach (var edgeProperty in edge.Properties)
+                {
+                    sqlRecord[0].Should().Be(edgeId);
+                    sqlRecord[1].Should().Be(edgeProperty.Key);
+                    sqlRecord[2].Should().Be(edgeProperty.Value);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#23629](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/23629)

Discovered these mistakes while testing https://github.com/CluedIn-io/CluedIn/pull/4674.
Fixed and added tests

Side notes: Was partially introduced here: https://github.com/CluedIn-io/CluedIn.Connector.SqlServer/pull/77/commits/04467fe3045fcc000310ce280092fd5b475c7aae

## Test approach <!-- Remove if not needed -->
Run new unit tests