### PR TITLE
chore: Add entity id to edge properties table

### DIFF
--- a/src/Connector.SqlServer/Utils/TableDefinitions/EdgePropertiesTableDefinition.cs
+++ b/src/Connector.SqlServer/Utils/TableDefinitions/EdgePropertiesTableDefinition.cs
@@ -1,5 +1,4 @@
 ﻿using CluedIn.Connector.SqlServer.Connector;
-using CluedIn.Core.Data;
 using CluedIn.Core.Streams.Models;
 using Microsoft.Data.SqlClient;
 using Microsoft.Data.SqlClient.Server;
@@ -20,6 +19,7 @@ namespace CluedIn.Connector.SqlServer.Utils.TableDefinitions
                     return new ColumnDefinition[]
                     {
                         new("EdgeId", SqlColumnHelper.UniqueIdentifier, IsPrimaryKey: true),
+                        new("EntityId", SqlColumnHelper.UniqueIdentifier),
                         new("KeyName", SqlColumnHelper.NVarchar256, IsPrimaryKey: true),
                         new("Value", SqlColumnHelper.GetColumnTypeForPropertyValue()),
                         new("ChangeType", SqlColumnHelper.Int),
@@ -30,6 +30,7 @@ namespace CluedIn.Connector.SqlServer.Utils.TableDefinitions
                     return new ColumnDefinition[]
                     {
                         new("EdgeId", SqlColumnHelper.UniqueIdentifier, IsPrimaryKey: true),
+                        new("EntityId", SqlColumnHelper.UniqueIdentifier),
                         new("KeyName", SqlColumnHelper.NVarchar256, IsPrimaryKey: true),
                         new("Value", SqlColumnHelper.GetColumnTypeForPropertyValue()),
                     };
@@ -57,10 +58,11 @@ namespace CluedIn.Connector.SqlServer.Utils.TableDefinitions
 
                                 var record = new SqlDataRecord(sqlMetaData);
                                 record.SetGuid(0, edgeId);
-                                record.SetString(1, property.Key);
-                                record.SetString(2, property.Value);
-                                record.SetInt32(3, (int)connectorEntityData.ChangeType);
-                                record.SetGuid(4, connectorEntityData.CorrelationId.Value);
+                                record.SetGuid(1, connectorEntityData.EntityId);
+                                record.SetString(2, property.Key);
+                                record.SetString(3, property.Value);
+                                record.SetInt32(4, (int)connectorEntityData.ChangeType);
+                                record.SetGuid(5, connectorEntityData.CorrelationId.Value);
 
                                 return record;
                             }));
@@ -77,8 +79,9 @@ namespace CluedIn.Connector.SqlServer.Utils.TableDefinitions
 
                                 var record = new SqlDataRecord(sqlMetaData);
                                 record.SetGuid(0, edgeId);
-                                record.SetString(1, property.Key);
-                                record.SetString(2, property.Value);
+                                record.SetGuid(1, connectorEntityData.EntityId);
+                                record.SetString(2, property.Key);
+                                record.SetString(3, property.Value);
 
                                 return record;
                             }));
@@ -135,21 +138,26 @@ namespace CluedIn.Connector.SqlServer.Utils.TableDefinitions
         {
             var edgePropertiesTableName = TableNameUtility.GetEdgePropertiesTableName(streamModel, direction, schema);
             var edgePropertiesTableType = CreateCustomTypeCommandUtility.GetEdgePropertiesTableCustomTypeName(streamModel, direction, schema);
-            var edgeTableName = TableNameUtility.GetEdgesTableName(streamModel, direction, schema);
+            var entityIdParameter = new SqlParameter("@EntityId", SqlDbType.UniqueIdentifier) { Value = connectorEntityData.EntityId };
+
+            var sqlDataRecords = GetSqlDataRecords(StreamMode.Sync, connectorEntityData, direction).ToArray();
+            if (!sqlDataRecords.Any())
+            {
+                // If there are no edge properties to be exported, we can use a simpler command,
+                // than if we have to potentially both delete and insert edge properties.
+                var simpleCommandText = $"""
+                    DELETE {edgePropertiesTableName.FullyQualifiedName}
+                    WHERE [EntityId] = @EntityId
+                    """;
+
+                return new SqlServerConnectorCommand { Text = simpleCommandText, Parameters = new[] { entityIdParameter } };
+            }
 
             var commandText = $"""
                 -- Delete existing columns that no longer exist
                 DELETE {edgePropertiesTableName.FullyQualifiedName}
                 WHERE
-                    EXISTS(
-                        SELECT
-                            1
-                        FROM
-                            {edgeTableName.FullyQualifiedName} edge
-                        WHERE
-                            edge.[Id] = {edgePropertiesTableName.FullyQualifiedName}.[EdgeId]
-                            AND edge.[EntityId] = @EntityId
-                    )
+                    {edgePropertiesTableName.FullyQualifiedName}.[EntityId] = @EntityId
                     AND NOT EXISTS(
                         SELECT
                             1
@@ -164,6 +172,7 @@ namespace CluedIn.Connector.SqlServer.Utils.TableDefinitions
                     {edgePropertiesTableName.FullyQualifiedName}
                 SELECT
                     newValues.[EdgeId],
+                    newValues.[EntityId],
                     newValues.[KeyName],
                     newValues.[Value]
                 FROM
@@ -174,14 +183,6 @@ namespace CluedIn.Connector.SqlServer.Utils.TableDefinitions
                     existingValues.[EdgeId] IS NULL
                 """;
 
-
-            var sqlDataRecords = GetSqlDataRecords(StreamMode.Sync, connectorEntityData, direction).ToArray();
-            if (!sqlDataRecords.Any())
-            {
-                sqlDataRecords = null;
-            }
-
-            var entityIdParameter = new SqlParameter("@EntityId", SqlDbType.UniqueIdentifier) { Value = connectorEntityData.EntityId };
             var recordsParameter = new SqlParameter($"@{edgePropertiesTableType.LocalName}", SqlDbType.Structured) { Value = sqlDataRecords, TypeName = edgePropertiesTableType.FullyQualifiedName };
 
             return new SqlServerConnectorCommand { Text = commandText, Parameters = new[] { entityIdParameter, recordsParameter } };

--- a/test/unit/Connector.SqlServer.Test/Utils/TableDefinitions/EdgePropertiesTableDefinitionTests.cs
+++ b/test/unit/Connector.SqlServer.Test/Utils/TableDefinitions/EdgePropertiesTableDefinitionTests.cs
@@ -76,10 +76,11 @@ namespace CluedIn.Connector.SqlServer.Unit.Tests.Utils.TableDefinitions
                 foreach (var edgeProperty in edge.Properties)
                 {
                     sqlRecord[0].Should().Be(edgeId);
-                    sqlRecord[1].Should().Be(edgeProperty.Key);
-                    sqlRecord[2].Should().Be(edgeProperty.Value);
-                    sqlRecord[3].Should().Be(VersionChangeType.Added);
-                    sqlRecord[4].Should().Be(correlationId);
+                    sqlRecord[1].Should().Be(entityId);
+                    sqlRecord[2].Should().Be(edgeProperty.Key);
+                    sqlRecord[3].Should().Be(edgeProperty.Value);
+                    sqlRecord[4].Should().Be(VersionChangeType.Added);
+                    sqlRecord[5].Should().Be(correlationId);
                 }
             }
         }
@@ -130,8 +131,9 @@ namespace CluedIn.Connector.SqlServer.Unit.Tests.Utils.TableDefinitions
                 foreach (var edgeProperty in edge.Properties)
                 {
                     sqlRecord[0].Should().Be(edgeId);
-                    sqlRecord[1].Should().Be(edgeProperty.Key);
-                    sqlRecord[2].Should().Be(edgeProperty.Value);
+                    sqlRecord[1].Should().Be(entityId);
+                    sqlRecord[2].Should().Be(edgeProperty.Key);
+                    sqlRecord[3].Should().Be(edgeProperty.Value);
                 }
             }
         }


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#23694](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/23694)

Add entity id to edge properties table. This simplifies the queries used for upserting properties, as well as fixes issue where edge property that had been removed in entity, was not removed from export target.


## Test approach <!-- Remove if not needed -->
Run new unit test. Manually tested.