### PR TITLE
chore: Disable multiple active result sets in connection string

### DIFF
--- a/src/Connector.SqlServer/Connector/SqlClient.cs
+++ b/src/Connector.SqlServer/Connector/SqlClient.cs
@@ -22,7 +22,6 @@ namespace CluedIn.Connector.SqlServer.Connector
                 DataSource = (string)config[SqlServerConstants.KeyName.Host],
                 InitialCatalog = (string)config[SqlServerConstants.KeyName.DatabaseName],
                 Pooling = true,
-                MultipleActiveResultSets = false,
                 MaxPoolSize = 200
             };
 

--- a/src/Connector.SqlServer/Connector/SqlClient.cs
+++ b/src/Connector.SqlServer/Connector/SqlClient.cs
@@ -22,7 +22,7 @@ namespace CluedIn.Connector.SqlServer.Connector
                 DataSource = (string)config[SqlServerConstants.KeyName.Host],
                 InitialCatalog = (string)config[SqlServerConstants.KeyName.DatabaseName],
                 Pooling = true,
-                MultipleActiveResultSets = true,
+                MultipleActiveResultSets = false,
                 MaxPoolSize = 200
             };
 

--- a/test/unit/Connector.SqlServer.Test/Connector/SqlClientTests.cs
+++ b/test/unit/Connector.SqlServer.Test/Connector/SqlClientTests.cs
@@ -26,7 +26,7 @@ namespace CluedIn.Connector.SqlServer.Unit.Tests.Connector
 
             var result = _sut.BuildConnectionString(properties);
 
-            Assert.Equal("Data Source=host,1433;Initial Catalog=database;User ID=user;Password=password;Pooling=True;Max Pool Size=200;Multiple Active Result Sets=True;Authentication=SqlPassword", result);
+            Assert.Equal("Data Source=host,1433;Initial Catalog=database;User ID=user;Password=password;Pooling=True;Max Pool Size=200;Authentication=SqlPassword", result);
         }
 
         [Fact]
@@ -43,7 +43,7 @@ namespace CluedIn.Connector.SqlServer.Unit.Tests.Connector
 
             var result = _sut.BuildConnectionString(properties);
 
-            Assert.Equal("Data Source=host,9499;Initial Catalog=database;User ID=user;Password=password;Pooling=True;Max Pool Size=200;Multiple Active Result Sets=True;Authentication=SqlPassword", result);
+            Assert.Equal("Data Source=host,9499;Initial Catalog=database;User ID=user;Password=password;Pooling=True;Max Pool Size=200;Authentication=SqlPassword", result);
         }
 
         [Fact]
@@ -60,7 +60,7 @@ namespace CluedIn.Connector.SqlServer.Unit.Tests.Connector
 
             var result = _sut.BuildConnectionString(properties);
 
-            Assert.Equal("Data Source=host,9499;Initial Catalog=database;User ID=user;Password=password;Pooling=True;Max Pool Size=200;Multiple Active Result Sets=True;Authentication=SqlPassword", result);
+            Assert.Equal("Data Source=host,9499;Initial Catalog=database;User ID=user;Password=password;Pooling=True;Max Pool Size=200;Authentication=SqlPassword", result);
         }
 
         [Fact]
@@ -77,7 +77,7 @@ namespace CluedIn.Connector.SqlServer.Unit.Tests.Connector
 
             var result = _sut.BuildConnectionString(properties);
 
-            Assert.Equal("Data Source=host,1433;Initial Catalog=database;User ID=user;Password=password;Pooling=True;Max Pool Size=200;Multiple Active Result Sets=True;Authentication=SqlPassword", result);
+            Assert.Equal("Data Source=host,1433;Initial Catalog=database;User ID=user;Password=password;Pooling=True;Max Pool Size=200;Authentication=SqlPassword", result);
         }
     }
 }

--- a/test/unit/Connector.SqlServer.Test/TestContext.cs
+++ b/test/unit/Connector.SqlServer.Test/TestContext.cs
@@ -177,7 +177,7 @@ namespace CluedIn.Connector.SqlServer.Unit.Tests
 
             // Setup
             Server.Setup(s => s.ApplicationContext).Returns(() => Container.Resolve<ApplicationContext>());
-            Bus.Setup(s => s.IsConnected).Returns(false);
+            //Bus.Setup(s => s.IsConnected).Returns(false);
             Bus.Setup(s => s.Advanced.IsConnected).Returns(false);
 
             OrganizationFactory = (ctx, id) => new TestOrganization(ctx.ApplicationContext, id);


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#29867](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/29867)


Disable `MultipleActiveResultSets`