### PR TITLE
fix: Explicitly dispose readers

### DIFF
--- a/src/Connector.SqlServer/Connector/SqlServerConnector.cs
+++ b/src/Connector.SqlServer/Connector/SqlServerConnector.cs
@@ -237,6 +237,8 @@ namespace CluedIn.Connector.SqlServer.Connector
                 var sqlCommand = command.ToSqlCommand(transaction);
                 var reader = await sqlCommand.ExecuteReaderAsync();
                 result = await LatestPersistInfoCommandUtility.ReadSinglePersistInfo(reader);
+
+                await reader.DisposeAsync();
             });
 
             return result;
@@ -257,6 +259,8 @@ namespace CluedIn.Connector.SqlServer.Connector
                 var sqlCommand = command.ToSqlCommand(transaction);
                 var reader = await sqlCommand.ExecuteReaderAsync();
                 result = LatestPersistInfoCommandUtility.ReadAllPersistInfos(reader);
+
+                await reader.DisposeAsync();
             });
 
             return result;

--- a/src/Connector.SqlServer/Utils/Upgrade/UpgradeCodeTableUtility.cs
+++ b/src/Connector.SqlServer/Utils/Upgrade/UpgradeCodeTableUtility.cs
@@ -32,6 +32,8 @@ namespace CluedIn.Connector.SqlServer.Utils.Upgrade
                 actualColumns.Add(reader[0].ToString());
             }
 
+            await reader.DisposeAsync();
+
             if (!actualColumns.Any())
             {
                 logger.LogInformation("Skipping adding IsDataPartOriginEntityCode to code table, since code table does not exist. This is most likely since `VerifyExistingContainer` is being ran before container is created");

--- a/src/Connector.SqlServer/Utils/Upgrade/UpgradeTo370Utility.cs
+++ b/src/Connector.SqlServer/Utils/Upgrade/UpgradeTo370Utility.cs
@@ -35,7 +35,7 @@ namespace CluedIn.Connector.SqlServer.Utils.Upgrade
                 var renameSqlConnectorCommand = new SqlServerConnectorCommand() { Text = tableRenameText, Parameters = Array.Empty<SqlParameter>() };
                 await renameSqlConnectorCommand
                     .ToSqlCommand(transaction)
-                    .ExecuteScalarAsync();
+                    .ExecuteNonQueryAsync();
             }
 
             // Check if old main table is present
@@ -100,6 +100,8 @@ namespace CluedIn.Connector.SqlServer.Utils.Upgrade
                         var exception = IncompatibleTableException.OldTableVersionExists(streamModel.Id, (Guid)streamModel.ConnectorProviderDefinitionId);
                         logger.LogError(exception, "Not all expected columns were present, most likely because the table was created in an old version");
                     }
+
+                    await reader.DisposeAsync();
                 }
             }
         }


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#30088](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/30088)

Explicitly dispose readers, since after we disabled MARS in #100, we will get an error if we try to commit a transaction, with multiple active readers.

## Test approach <!-- Remove if not needed -->
Manually tested, including method specified in [AB#30088](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/30088)
