### PR TITLE
fix: Prepend table names starting with digit

### DIFF
--- a/src/Connector.SqlServer/Utils/StringExtensions.cs
+++ b/src/Connector.SqlServer/Utils/StringExtensions.cs
@@ -11,7 +11,8 @@ namespace CluedIn.Connector.SqlServer.Utils
         {
             var withoutSpecialCharacters = Regex.Replace(value, @"[^_A-Za-z0-9]+", string.Empty);
 
-            if (Regex.IsMatch(withoutSpecialCharacters, @"^\d.*"))
+            if (withoutSpecialCharacters.Length > 0 &&
+                char.IsDigit(withoutSpecialCharacters[0]))
             {
                 return $"Table{withoutSpecialCharacters}";
             }

--- a/src/Connector.SqlServer/Utils/StringExtensions.cs
+++ b/src/Connector.SqlServer/Utils/StringExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.RegularExpressions;
+﻿using System;
+using System.Text.RegularExpressions;
 
 namespace CluedIn.Connector.SqlServer.Utils
 {
@@ -11,8 +12,12 @@ namespace CluedIn.Connector.SqlServer.Utils
         {
             var withoutSpecialCharacters = Regex.Replace(value, @"[^_A-Za-z0-9]+", string.Empty);
 
-            if (withoutSpecialCharacters.Length > 0 &&
-                char.IsDigit(withoutSpecialCharacters[0]))
+            if (withoutSpecialCharacters.Length == 0)
+            {
+                throw new ArgumentException($"Input value contained only non-alphanumeric characters, or was empty: '{value}'", nameof(value));
+            }
+
+            if (char.IsDigit(withoutSpecialCharacters[0]))
             {
                 return $"Table{withoutSpecialCharacters}";
             }

--- a/src/Connector.SqlServer/Utils/StringExtensions.cs
+++ b/src/Connector.SqlServer/Utils/StringExtensions.cs
@@ -10,19 +10,19 @@ namespace CluedIn.Connector.SqlServer.Utils
         /// </summary>
         public static string ToSanitizedSqlName(this string value)
         {
-            var withoutSpecialCharacters = Regex.Replace(value, @"[^_A-Za-z0-9]+", string.Empty);
+            var sanitizedSqlName = Regex.Replace(value, @"[^_A-Za-z0-9]+", string.Empty);
 
-            if (withoutSpecialCharacters.Length == 0)
+            if (sanitizedSqlName.Length == 0)
             {
                 throw new ArgumentException($"Input value contained only non-alphanumeric characters, or was empty: '{value}'", nameof(value));
             }
 
-            if (char.IsDigit(withoutSpecialCharacters[0]))
+            if (char.IsDigit(sanitizedSqlName[0]))
             {
-                return $"Table{withoutSpecialCharacters}";
+                sanitizedSqlName = $"Table{sanitizedSqlName}";
             }
 
-            return withoutSpecialCharacters;
+            return sanitizedSqlName;
         }
     }
 }

--- a/src/Connector.SqlServer/Utils/StringExtensions.cs
+++ b/src/Connector.SqlServer/Utils/StringExtensions.cs
@@ -9,7 +9,14 @@ namespace CluedIn.Connector.SqlServer.Utils
         /// </summary>
         public static string ToSanitizedSqlName(this string value)
         {
-            return Regex.Replace(value, @"[^_A-Za-z0-9]+", string.Empty);
+            var withoutSpecialCharacters = Regex.Replace(value, @"[^_A-Za-z0-9]+", string.Empty);
+
+            if (Regex.IsMatch(withoutSpecialCharacters, @"^\d.*"))
+            {
+                return $"Table{withoutSpecialCharacters}";
+            }
+
+            return withoutSpecialCharacters;
         }
     }
 }

--- a/test/unit/Connector.SqlServer.Test/Utils/StringExtensionsTests.cs
+++ b/test/unit/Connector.SqlServer.Test/Utils/StringExtensionsTests.cs
@@ -1,0 +1,27 @@
+﻿using AutoFixture.Xunit2;
+using CluedIn.Connector.SqlServer.Utils;
+using FluentAssertions;
+using Xunit;
+
+namespace CluedIn.Connector.SqlServer.Unit.Tests.Utils;
+
+public class StringExtensionsTests
+{
+    [Theory]
+    [InlineAutoData("TableName", "TableName")]
+    [InlineAutoData("TableName1", "TableName1")]
+    [InlineAutoData("TableName+", "TableName")]
+    [InlineAutoData("+TableName", "TableName")]
+    [InlineAutoData("1", "Table1")]
+    [InlineAutoData("123", "Table123")]
+    [InlineAutoData("1Table", "Table1Table")]
+    public void ToSanitizedTableName_ShouldYieldName(string input, string expectedOutput)
+    {
+        // arrange
+        // act
+        var result = input.ToSanitizedSqlName();
+
+        // assert
+        result.Should().Be(expectedOutput);
+    }
+}

--- a/test/unit/Connector.SqlServer.Test/Utils/StringExtensionsTests.cs
+++ b/test/unit/Connector.SqlServer.Test/Utils/StringExtensionsTests.cs
@@ -1,6 +1,7 @@
 ﻿using AutoFixture.Xunit2;
 using CluedIn.Connector.SqlServer.Utils;
 using FluentAssertions;
+using System;
 using Xunit;
 
 namespace CluedIn.Connector.SqlServer.Unit.Tests.Utils;
@@ -23,5 +24,18 @@ public class StringExtensionsTests
 
         // assert
         result.Should().Be(expectedOutput);
+    }
+
+    [Theory]
+    [InlineAutoData("!@#")]
+    [InlineAutoData("")]
+    public void ToSanitizedTableName_ShouldThrow(string input)
+    {
+        // Arrange
+        // Act
+        var action = () => input.ToSanitizedSqlName();
+
+        // Assert
+        action.Should().Throw<ArgumentException>();
     }
 }


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#30652](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/30652)

Prepend table name with `Table`, if the table name starts with a digit. This is because table names cannot start with digits.

UI:
![image](https://github.com/CluedIn-io/CluedIn.Connector.SqlServer/assets/39338793/d68dea5d-51ec-463d-bc17-d9d2f56cfd23)
