### PR TITLE
fix: Cap length of column name

### DIFF
--- a/docs/4.0.0-release-notes.md
+++ b/docs/4.0.0-release-notes.md
@@ -7,4 +7,5 @@
   This is to mirror change in platform, and to improve performance.
 
 ### Fixes
-- Prepend tablename with "Table", if it starts with a digit, since table names cannot start with digits in mssql.
+- Prepend tablename with underscore, if it starts with a digit, since table names cannot start with digits in mssql.
+- Cap length column names, and append hash value of name, to ensure uniqueness

--- a/src/Connector.SqlServer/Utils/StringExtensions.cs
+++ b/src/Connector.SqlServer/Utils/StringExtensions.cs
@@ -24,8 +24,8 @@ namespace CluedIn.Connector.SqlServer.Utils
 
             if (sanitizedSqlName.Length > 127) // 127 instead of 128, since we need space for parameter declaration '@'
             {
-                var hashValue = Math.Abs(GetStableHashCode(value)).ToString().PadLeft(10, '0');
-                var postFix = $"_{hashValue}";
+                var hashValue = Math.Abs(GetStableHashCode(value));
+                var postFix = $"_{hashValue:x8}";
                 sanitizedSqlName = $"{sanitizedSqlName.Remove(127 - postFix.Length)}{postFix}";
             }
 

--- a/src/Connector.SqlServer/Utils/StringExtensions.cs
+++ b/src/Connector.SqlServer/Utils/StringExtensions.cs
@@ -22,7 +22,35 @@ namespace CluedIn.Connector.SqlServer.Utils
                 sanitizedSqlName = $"Table{sanitizedSqlName}";
             }
 
+            if (sanitizedSqlName.Length > 127) // 127 instead of 128, since we need space for parameter declaration '@'
+            {
+                var hashValue = Math.Abs(GetStableHashCode(value)).ToString().PadLeft(10, '0');
+                var postFix = $"_{hashValue}";
+                sanitizedSqlName = $"{sanitizedSqlName.Remove(127 - postFix.Length)}{postFix}";
+            }
+
             return sanitizedSqlName;
+        }
+
+        // # .NET implementation of string hash code copied from here:
+        // https://stackoverflow.com/a/36845864/2009373
+        private static int GetStableHashCode(string str)
+        {
+            unchecked
+            {
+                int hash1 = 5381;
+                int hash2 = hash1;
+
+                for (int i = 0; i < str.Length && str[i] != '\0'; i += 2)
+                {
+                    hash1 = ((hash1 << 5) + hash1) ^ str[i];
+                    if (i == str.Length - 1 || str[i + 1] == '\0')
+                        break;
+                    hash2 = ((hash2 << 5) + hash2) ^ str[i + 1];
+                }
+
+                return hash1 + (hash2 * 1566083941);
+            }
         }
     }
 }

--- a/src/Connector.SqlServer/Utils/StringExtensions.cs
+++ b/src/Connector.SqlServer/Utils/StringExtensions.cs
@@ -19,7 +19,7 @@ namespace CluedIn.Connector.SqlServer.Utils
 
             if (char.IsDigit(sanitizedSqlName[0]))
             {
-                sanitizedSqlName = $"Table{sanitizedSqlName}";
+                sanitizedSqlName = $"_{sanitizedSqlName}";
             }
 
             if (sanitizedSqlName.Length > 127) // 127 instead of 128, since we need space for parameter declaration '@'

--- a/test/unit/Connector.SqlServer.Test/Utils/StringExtensionsTests.cs
+++ b/test/unit/Connector.SqlServer.Test/Utils/StringExtensionsTests.cs
@@ -16,6 +16,7 @@ public class StringExtensionsTests
     [InlineAutoData("1", "Table1")]
     [InlineAutoData("123", "Table123")]
     [InlineAutoData("1Table", "Table1Table")]
+    [InlineAutoData("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_0392220648")] // Expected result should not be changed, since we need to ensure that hash is stable
     public void ToSanitizedTableName_ShouldYieldName(string input, string expectedOutput)
     {
         // arrange
@@ -37,5 +38,19 @@ public class StringExtensionsTests
 
         // Assert
         action.Should().Throw<ArgumentException>();
+    }
+
+    [Theory]
+    [InlineAutoData("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]
+    [InlineAutoData("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")]
+    [InlineAutoData("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc")]
+    public void ToSanitizedTableName_ShouldLimitSize(string input)
+    {
+        // arrange
+        // act
+        var result = input.ToSanitizedSqlName();
+
+        // assert
+        result.Length.Should().Be(127);
     }
 }

--- a/test/unit/Connector.SqlServer.Test/Utils/StringExtensionsTests.cs
+++ b/test/unit/Connector.SqlServer.Test/Utils/StringExtensionsTests.cs
@@ -16,7 +16,7 @@ public class StringExtensionsTests
     [InlineAutoData("1", "_1")]
     [InlineAutoData("123", "_123")]
     [InlineAutoData("1Table", "_1Table")]
-    [InlineAutoData("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_0392220648")] // Expected result should not be changed, since we need to ensure that hash is stable
+    [InlineAutoData("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_1760cfe8")] // Expected result should not be changed, since we need to ensure that hash is stable
     public void ToSanitizedTableName_ShouldYieldName(string input, string expectedOutput)
     {
         // arrange

--- a/test/unit/Connector.SqlServer.Test/Utils/StringExtensionsTests.cs
+++ b/test/unit/Connector.SqlServer.Test/Utils/StringExtensionsTests.cs
@@ -13,9 +13,9 @@ public class StringExtensionsTests
     [InlineAutoData("TableName1", "TableName1")]
     [InlineAutoData("TableName+", "TableName")]
     [InlineAutoData("+TableName", "TableName")]
-    [InlineAutoData("1", "Table1")]
-    [InlineAutoData("123", "Table123")]
-    [InlineAutoData("1Table", "Table1Table")]
+    [InlineAutoData("1", "_1")]
+    [InlineAutoData("123", "_123")]
+    [InlineAutoData("1Table", "_1Table")]
     [InlineAutoData("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_0392220648")] // Expected result should not be changed, since we need to ensure that hash is stable
     public void ToSanitizedTableName_ShouldYieldName(string input, string expectedOutput)
     {


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#30770](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/30770)

Cap length of column names.

## Test approach <!-- Remove if not needed -->
Run stream/new unit test

## Release Note <!-- Remove if not needed -->
fix: Cap length of column names. If names are longer than 127 characters, we cut off anything after character 116, and append hash value of the entire name.
