### PR TITLE
chore: Refactor store queries, to be executed in single command

### DIFF
--- a/docs/4.0.0-release-notes.md
+++ b/docs/4.0.0-release-notes.md
@@ -5,6 +5,7 @@
 - Updated to .NET6
 - Disable MARS (multiple active result sets).
   This is to mirror change in platform, and to improve performance.
+- Refactor queries, so that fewer round trips are needed to store entity.
 
 ### Fixes
 - Prepend tablename with underscore, if it starts with a digit, since table names cannot start with digits in mssql.

--- a/src/Connector.SqlServer/Connector/SqlServerConnector.cs
+++ b/src/Connector.SqlServer/Connector/SqlServerConnector.cs
@@ -152,29 +152,48 @@ namespace CluedIn.Connector.SqlServer.Connector
 
         private async Task<SaveResult> ExecuteDelete(IReadOnlyStreamModel streamModel, SqlConnectorEntityData sqlConnectorEntityData, SqlName schema, SqlTransaction transaction)
         {
+            var commandsToRun = new List<SqlServerConnectorCommand>();
+
             if (streamModel.ExportIncomingEdges)
             {
                 var deleteEdgeIncomingPropertiesCommand = StoreCommandBuilder.DeleteEdgePropertiesForEntity(streamModel, sqlConnectorEntityData, EdgeDirection.Incoming, schema);
-                await deleteEdgeIncomingPropertiesCommand.ToSqlCommand(transaction).ExecuteNonQueryAsync();
+                commandsToRun.Add(deleteEdgeIncomingPropertiesCommand);
 
                 var deleteEdgesIncomingCommand = StoreCommandBuilder.DeleteEdgesForEntity(streamModel, sqlConnectorEntityData, EdgeDirection.Incoming, schema);
-                await deleteEdgesIncomingCommand.ToSqlCommand(transaction).ExecuteNonQueryAsync();
+                commandsToRun.Add(deleteEdgesIncomingCommand);
             }
 
             if (streamModel.ExportOutgoingEdges)
             {
                 var deleteEdgeOutgoingPropertiesCommand = StoreCommandBuilder.DeleteEdgePropertiesForEntity(streamModel, sqlConnectorEntityData, EdgeDirection.Outgoing, schema);
-                await deleteEdgeOutgoingPropertiesCommand.ToSqlCommand(transaction).ExecuteNonQueryAsync();
+                commandsToRun.Add(deleteEdgeOutgoingPropertiesCommand);
 
                 var deleteEdgesOutgoingCommand = StoreCommandBuilder.DeleteEdgesForEntity(streamModel, sqlConnectorEntityData, EdgeDirection.Outgoing, schema);
-                await deleteEdgesOutgoingCommand.ToSqlCommand(transaction).ExecuteNonQueryAsync();
+                commandsToRun.Add(deleteEdgesOutgoingCommand);
             }
 
             var deleteCodesCommand = StoreCommandBuilder.DeleteCodesForEntity(streamModel, sqlConnectorEntityData, schema);
-            await deleteCodesCommand.ToSqlCommand(transaction).ExecuteNonQueryAsync();
+            commandsToRun.Add(deleteCodesCommand);
 
             var deleteMainCommand = StoreCommandBuilder.DeleteEntity(streamModel, sqlConnectorEntityData, schema);
-            await deleteMainCommand.ToSqlCommand(transaction).ExecuteNonQueryAsync();
+            commandsToRun.Add(deleteMainCommand);
+
+            var gatheredCommandText = string.Join("""
+
+
+                                                  -- Command split
+
+
+                                                  """, commandsToRun.Select(command => command.Text));
+
+            var gatheredParameters = commandsToRun.SelectMany(command => command.Parameters);
+
+            var gatheredCommand = transaction.Connection.CreateCommand();
+            gatheredCommand.CommandText = gatheredCommandText;
+            gatheredCommand.Parameters.AddRange(gatheredParameters.ToArray());
+            gatheredCommand.Transaction = transaction;
+
+            await gatheredCommand.ExecuteNonQueryAsync();
 
             return SaveResult.Success;
         }
@@ -183,41 +202,54 @@ namespace CluedIn.Connector.SqlServer.Connector
         {
             var isSyncMode = streamModel.Mode == StreamMode.Sync;
 
+            var commandsToRun = new List<SqlServerConnectorCommand>();
+
             var updateCommand = StoreCommandBuilder.MainTableCommand(streamModel, sqlConnectorEntityData, schema);
-            var updateSqlCommand = updateCommand.ToSqlCommand(transaction);
-            await updateSqlCommand.ExecuteNonQueryAsync();
+            commandsToRun.Add(updateCommand);
 
             var insertCodesCommand = StoreCommandBuilder.CodesInsertCommand(streamModel, sqlConnectorEntityData, schema);
-            var insertCodeSqlCommand = insertCodesCommand.ToSqlCommand(transaction);
-            await insertCodeSqlCommand.ExecuteNonQueryAsync();
+            commandsToRun.Add(insertCodesCommand);
 
             if (streamModel.ExportIncomingEdges && (isSyncMode || sqlConnectorEntityData.IncomingEdges.Any()))
             {
                 var incomingEdgesCommand = StoreCommandBuilder.EdgesCommand(streamModel, sqlConnectorEntityData, EdgeDirection.Incoming, schema);
-                var incomingEdgesSqlCommand = incomingEdgesCommand.ToSqlCommand(transaction);
-                await incomingEdgesSqlCommand.ExecuteNonQueryAsync();
+                commandsToRun.Add(incomingEdgesCommand);
 
                 if (isSyncMode || sqlConnectorEntityData.IncomingEdges.Any(edge => edge.HasProperties))
                 {
                     var incomingEdgePropertiesCommand = StoreCommandBuilder.EdgePropertiesCommand(streamModel, sqlConnectorEntityData, EdgeDirection.Incoming, schema);
-                    var incomingEdgePropertiesSqlCommand = incomingEdgePropertiesCommand.ToSqlCommand(transaction);
-                    await incomingEdgePropertiesSqlCommand.ExecuteNonQueryAsync();
+                    commandsToRun.Add(incomingEdgePropertiesCommand);
                 }
             }
 
             if (streamModel.ExportOutgoingEdges && (isSyncMode || sqlConnectorEntityData.OutgoingEdges.Any()))
             {
                 var outgoingEdgesCommand = StoreCommandBuilder.EdgesCommand(streamModel, sqlConnectorEntityData, EdgeDirection.Outgoing, schema);
-                var outgoingEdgesSqlCommand = outgoingEdgesCommand.ToSqlCommand(transaction);
-                await outgoingEdgesSqlCommand.ExecuteNonQueryAsync();
+                commandsToRun.Add(outgoingEdgesCommand);
 
                 if (isSyncMode || sqlConnectorEntityData.OutgoingEdges.Any(edge => edge.HasProperties))
                 {
                     var outgoingEdgePropertiesCommand = StoreCommandBuilder.EdgePropertiesCommand(streamModel, sqlConnectorEntityData, EdgeDirection.Outgoing, schema);
-                    var outgoingEdgePropertiesSqlCommand = outgoingEdgePropertiesCommand.ToSqlCommand(transaction);
-                    await outgoingEdgePropertiesSqlCommand.ExecuteNonQueryAsync();
+                    commandsToRun.Add(outgoingEdgePropertiesCommand);
                 }
             }
+
+            var gatheredCommandText = string.Join("""
+
+
+                                                  -- Command split
+
+
+                                                  """, commandsToRun.Select(command => command.Text));
+
+            var gatheredParameters = commandsToRun.SelectMany(command => command.Parameters);
+
+            var gatheredCommand = transaction.Connection.CreateCommand();
+            gatheredCommand.CommandText = gatheredCommandText;
+            gatheredCommand.Parameters.AddRange(gatheredParameters.ToArray());
+            gatheredCommand.Transaction = transaction;
+
+            await gatheredCommand.ExecuteNonQueryAsync();
 
             return SaveResult.Success;
         }

--- a/src/Connector.SqlServer/Utils/StoreCommandBuilder.cs
+++ b/src/Connector.SqlServer/Utils/StoreCommandBuilder.cs
@@ -33,15 +33,16 @@ namespace CluedIn.Connector.SqlServer.Utils
         {
             var edgeTableName = TableNameUtility.GetEdgesTableName(streamModel, edgeDirection, schema);
             var edgePropertiesTableName = TableNameUtility.GetEdgePropertiesTableName(streamModel, edgeDirection, schema);
+            var variablePrefix = $"{edgeDirection}_edge_properties_table_";
 
             var commandText = $"""
                 DELETE edgeProperties
-                FROM (SELECT [Id] as [Id] FROM {edgeTableName.FullyQualifiedName} WHERE [EntityId] = @EntityId) edges
+                FROM (SELECT [Id] as [Id] FROM {edgeTableName.FullyQualifiedName} WHERE [EntityId] = @{variablePrefix}EntityId) edges
                 INNER JOIN {edgePropertiesTableName.FullyQualifiedName} edgeProperties
                 ON edges.[Id] = edgeProperties.[EdgeId]
                 """;
 
-            var entityIdParameter = new SqlParameter("@EntityId", SqlDbType.UniqueIdentifier) { Value = connectorEntityData.EntityId };
+            var entityIdParameter = new SqlParameter($"@{variablePrefix}EntityId", SqlDbType.UniqueIdentifier) { Value = connectorEntityData.EntityId };
 
             return new SqlServerConnectorCommand() { Text = commandText, Parameters = new[] { entityIdParameter } };
         }
@@ -49,10 +50,11 @@ namespace CluedIn.Connector.SqlServer.Utils
         public static SqlServerConnectorCommand DeleteEdgesForEntity(IReadOnlyStreamModel streamModel, SqlConnectorEntityData connectorEntityData, EdgeDirection edgeDirection, SqlName schema)
         {
             var edgeTableName = TableNameUtility.GetEdgesTableName(streamModel, edgeDirection, schema);
+            var variablePrefix = $"{edgeDirection}_edge_table_";
 
-            var commandText = $"DELETE FROM {edgeTableName} WHERE [EntityId] = @EntityId";
+            var commandText = $"DELETE FROM {edgeTableName} WHERE [EntityId] = @{variablePrefix}EntityId";
 
-            var entityIdParameter = new SqlParameter("@EntityId", SqlDbType.UniqueIdentifier) { Value = connectorEntityData.EntityId };
+            var entityIdParameter = new SqlParameter($"@{variablePrefix}EntityId", SqlDbType.UniqueIdentifier) { Value = connectorEntityData.EntityId };
 
             return new SqlServerConnectorCommand() { Text = commandText, Parameters = new[] { entityIdParameter } };
         }
@@ -60,10 +62,11 @@ namespace CluedIn.Connector.SqlServer.Utils
         public static SqlServerConnectorCommand DeleteCodesForEntity(IReadOnlyStreamModel streamModel, SqlConnectorEntityData connectorEntityData, SqlName schema)
         {
             var codeTableName = TableNameUtility.GetCodeTableName(streamModel, schema);
+            var variablePrefix = "code_table_";
 
-            var commandText = $"DELETE FROM {codeTableName} WHERE [EntityId] = @EntityId";
+            var commandText = $"DELETE FROM {codeTableName} WHERE [EntityId] = @{variablePrefix}EntityId";
 
-            var entityIdParameter = new SqlParameter("@EntityId", SqlDbType.UniqueIdentifier) { Value = connectorEntityData.EntityId };
+            var entityIdParameter = new SqlParameter($"@{variablePrefix}EntityId", SqlDbType.UniqueIdentifier) { Value = connectorEntityData.EntityId };
 
             return new SqlServerConnectorCommand() { Text = commandText, Parameters = new[] { entityIdParameter } };
         }


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#30895](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/30895)

Refactor so that store/delete queries are executed in single command, cutting down on round trips, to improve performance.

## Test approach <!-- Remove if not needed -->
Run stream, streaming entities, and merge entities to test delete.

## Release Note <!-- Remove if not needed -->
chore: Refactor queries, so that fewer round trips are needed to store entity.