### PR TITLE
chore: Add index for EntityId in edge properties tables

### DIFF
--- a/src/Connector.SqlServer/Utils/TableDefinitions/EdgePropertiesTableDefinition.cs
+++ b/src/Connector.SqlServer/Utils/TableDefinitions/EdgePropertiesTableDefinition.cs
@@ -19,7 +19,7 @@ namespace CluedIn.Connector.SqlServer.Utils.TableDefinitions
                     return new ColumnDefinition[]
                     {
                         new("EdgeId", SqlColumnHelper.UniqueIdentifier, IsPrimaryKey: true),
-                        new("EntityId", SqlColumnHelper.UniqueIdentifier),
+                        new("EntityId", SqlColumnHelper.UniqueIdentifier, AddIndex: true),
                         new("KeyName", SqlColumnHelper.NVarchar256, IsPrimaryKey: true),
                         new("Value", SqlColumnHelper.GetColumnTypeForPropertyValue()),
                         new("ChangeType", SqlColumnHelper.Int),
@@ -30,7 +30,7 @@ namespace CluedIn.Connector.SqlServer.Utils.TableDefinitions
                     return new ColumnDefinition[]
                     {
                         new("EdgeId", SqlColumnHelper.UniqueIdentifier, IsPrimaryKey: true),
-                        new("EntityId", SqlColumnHelper.UniqueIdentifier),
+                        new("EntityId", SqlColumnHelper.UniqueIdentifier, AddIndex: true),
                         new("KeyName", SqlColumnHelper.NVarchar256, IsPrimaryKey: true),
                         new("Value", SqlColumnHelper.GetColumnTypeForPropertyValue()),
                     };


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#30693](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/30693)

Add index on `EntityId` in edge properties table, since we filter on it in multiple queries. Without it, we have a queryplan like this:
![image](https://github.com/CluedIn-io/CluedIn.Connector.SqlServer/assets/39338793/c46f7665-55fe-451c-9f1f-e91f2bc71698)

With the index, the query plan for the same query looks like this:
![image](https://github.com/CluedIn-io/CluedIn.Connector.SqlServer/assets/39338793/26c8de9a-bee9-4bc1-8964-412f98566fce)
The table scan in the query plan, is of the table we pass as parameter.


## Test approach <!-- Remove if not needed -->
Create stream that exports edge properties, observe that indexes are added
