### PR TITLE
fix: Specifically format DateTimeOffset properties

### DIFF
--- a/src/Connector.SqlServer/Utils/TableDefinitions/MainTableDefinition.cs
+++ b/src/Connector.SqlServer/Utils/TableDefinitions/MainTableDefinition.cs
@@ -72,6 +72,11 @@ namespace CluedIn.Connector.SqlServer.Utils.TableDefinitions
                                 return $"[{string.Join(", ", enumerable)}]";
                             }
 
+                            if (propertyValue is DateTime dateTimeValue)
+                            {
+                                return dateTimeValue.ToString("O");
+                            }
+
                             if (propertyValue is DateTimeOffset dateTimeOffsetValue)
                             {
                                 return dateTimeOffsetValue.ToString("O");

--- a/src/Connector.SqlServer/Utils/TableDefinitions/MainTableDefinition.cs
+++ b/src/Connector.SqlServer/Utils/TableDefinitions/MainTableDefinition.cs
@@ -72,6 +72,11 @@ namespace CluedIn.Connector.SqlServer.Utils.TableDefinitions
                                 return $"[{string.Join(", ", enumerable)}]";
                             }
 
+                            if (propertyValue is DateTimeOffset dateTimeOffsetValue)
+                            {
+                                return dateTimeOffsetValue.ToString("O");
+                            }
+
                             return propertyValue;
                         },
                         CanBeNull: true);

--- a/test/unit/Connector.SqlServer.Test/Utils/TableDefinitions/MainTableDefinitionTests.cs
+++ b/test/unit/Connector.SqlServer.Test/Utils/TableDefinitions/MainTableDefinitionTests.cs
@@ -105,11 +105,11 @@ namespace CluedIn.Connector.SqlServer.Unit.Tests.Utils.TableDefinitions
             // arrange
             var properties = new (string, ConnectorPropertyDataType)[]
             {
-                ("DiscoveryDate", new EntityPropertyConnectorPropertyDataType(typeof(DateTime))),
+                ("DiscoveryDate", new EntityPropertyConnectorPropertyDataType(typeof(DateTimeOffset))),
             };
             var dateValue = new DateTimeOffset(2000, 1, 1, 1, 1, 1, 0, offset: TimeSpan.FromHours(1));
 
-            var discoveryDatePropertyDate = new ConnectorPropertyData("DiscoveryDate", dateValue, new EntityPropertyConnectorPropertyDataType(typeof(DateTime)));
+            var discoveryDatePropertyDate = new ConnectorPropertyData("DiscoveryDate", dateValue, new EntityPropertyConnectorPropertyDataType(typeof(DateTimeOffset)));
             var connectorEntityData = new ConnectorEntityData(versionChangeType, StreamMode.Sync, entityId, null, null, null, null, new[] { discoveryDatePropertyDate }, Array.Empty<IEntityCode>(), Array.Empty<EntityEdge>(), Array.Empty<EntityEdge>());
             var sqlDiscoveryDatePropertyDate = new SqlConnectorEntityData(connectorEntityData, correlationId, timestamp: DateTimeOffset.Now);
 

--- a/test/unit/Connector.SqlServer.Test/Utils/TableDefinitions/MainTableDefinitionTests.cs
+++ b/test/unit/Connector.SqlServer.Test/Utils/TableDefinitions/MainTableDefinitionTests.cs
@@ -1,11 +1,13 @@
 ﻿using CluedIn.Connector.SqlServer.Unit.Tests.Customizations;
+using CluedIn.Connector.SqlServer.Utils;
 using CluedIn.Connector.SqlServer.Utils.TableDefinitions;
 using CluedIn.Core.Connectors;
+using CluedIn.Core.Data;
+using CluedIn.Core.Data.Parts;
 using CluedIn.Core.Data.Vocabularies;
 using CluedIn.Core.Streams.Models;
 using FluentAssertions;
 using System;
-using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using Xunit;
@@ -66,6 +68,58 @@ namespace CluedIn.Connector.SqlServer.Unit.Tests.Utils.TableDefinitions
             // assert
             syncColumnDefinitions.Should().ContainSingle(column => column.Name == "PersistVersion");
             eventColumnDefinitions.Should().ContainSingle(column => column.Name == "PersistVersion");
+        }
+
+        [Theory, AutoNData]
+        public void DateTimePropertyValues_ShouldBeToISO8601(
+            VersionChangeType versionChangeType,
+            Guid entityId,
+            Guid correlationId)
+        {
+            // arrange
+            var properties = new (string, ConnectorPropertyDataType)[]
+            {
+                ("DiscoveryDate", new EntityPropertyConnectorPropertyDataType(typeof(DateTime))),
+            };
+            var dateValue = new DateTime(2000, 1, 1, 1, 1, 1);
+
+            var discoveryDatePropertyDate = new ConnectorPropertyData("DiscoveryDate", dateValue, new EntityPropertyConnectorPropertyDataType(typeof(DateTime)));
+            var connectorEntityData = new ConnectorEntityData(versionChangeType, StreamMode.Sync, entityId, null, null, null, null, new[] { discoveryDatePropertyDate }, Array.Empty<IEntityCode>(), Array.Empty<EntityEdge>(), Array.Empty<EntityEdge>());
+            var sqlDiscoveryDatePropertyDate = new SqlConnectorEntityData(connectorEntityData, correlationId, timestamp: DateTimeOffset.Now);
+
+            // act
+            var syncColumnDefinitions = MainTableDefinition.GetColumnDefinitions(StreamMode.Sync, properties);
+
+            // assert
+            var discoveryDateColumnDefinition = syncColumnDefinitions.Where(column => column.Name == "DiscoveryDate").Should().ContainSingle().And.Subject.First();
+            var sqlDateValue = discoveryDateColumnDefinition.GetValueFunc(sqlDiscoveryDatePropertyDate);
+            sqlDateValue.Should().Be("2000-01-01T01:01:01.0000000");
+        }
+
+        [Theory, AutoNData]
+        public void DateTimeOffsetPropertyValues_ShouldBeToISO8601(
+            VersionChangeType versionChangeType,
+            Guid entityId,
+            Guid correlationId)
+        {
+            // arrange
+            var properties = new (string, ConnectorPropertyDataType)[]
+            {
+                ("DiscoveryDate", new EntityPropertyConnectorPropertyDataType(typeof(DateTime))),
+            };
+            var dateValue = new DateTimeOffset(2000, 1, 1, 1, 1, 1, 0, offset: TimeSpan.FromHours(1));
+
+            var discoveryDatePropertyDate = new ConnectorPropertyData("DiscoveryDate", dateValue, new EntityPropertyConnectorPropertyDataType(typeof(DateTime)));
+            var connectorEntityData = new ConnectorEntityData(versionChangeType, StreamMode.Sync, entityId, null, null, null, null, new[] { discoveryDatePropertyDate }, Array.Empty<IEntityCode>(), Array.Empty<EntityEdge>(), Array.Empty<EntityEdge>());
+            var sqlDiscoveryDatePropertyDate = new SqlConnectorEntityData(connectorEntityData, correlationId, timestamp: DateTimeOffset.Now);
+
+            // act
+            var syncColumnDefinitions = MainTableDefinition.GetColumnDefinitions(StreamMode.Sync, properties);
+
+            // assert
+            var discoveryDateColumnDefinition = syncColumnDefinitions.Where(column => column.Name == "DiscoveryDate").Should().ContainSingle().And.Subject.First();
+            var sqlDateValue = discoveryDateColumnDefinition.GetValueFunc(sqlDiscoveryDatePropertyDate);
+            sqlDateValue.Should().Be("2000-01-01T01:01:01.0000000+01:00");
         }
     }
 }


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#36302](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/36302)

Add cases for formatting `DateTime` and `DateTimeOffset` properties in ISO8601 format. Add unit tests of this.

## How has it been tested? <!-- Remove if not needed -->
Unit tests added.
Manually tested using both versions of platform passing `DateTime` and `DateTimeOffset`.

## Release Note <!-- Remove if not needed -->
chore: All `DateTime` and `DateTimeOffset` properties will be formatted in ISO8601 format.
