### PR TITLE
chore: Do not install .NET SDK explicitly on build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,11 +37,6 @@ variables:
 
 steps:
 
-  - task: UseDotNet@2
-    displayName: Install .NET SDK 6.0
-    inputs:
-      version: 6.0.x
-
   # Configure NuGet
   - task: NuGetAuthenticate@1
     displayName: 'Authenticate with nuget'


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
The build pipeline template we are using is already installing SDK using `global.json`, so no need to install it explicitly.
