### PR TITLE
feat: Make Connection pool size configurable

### DIFF
--- a/src/Connector.SqlServer/Connector/ISqlClient.cs
+++ b/src/Connector.SqlServer/Connector/ISqlClient.cs
@@ -5,8 +5,12 @@ using System.Threading.Tasks;
 
 namespace CluedIn.Connector.SqlServer.Connector
 {
+    public record ConnectionConfigurationError(string ErrorMessage);
+
     public interface ISqlClient
     {
+        bool VerifyConnectionProperties(IReadOnlyDictionary<string, object> config, out ConnectionConfigurationError configurationError);
+
         Task<SqlConnection> BeginConnection(IReadOnlyDictionary<string, object> config);
 
         Task<DataTable> GetTableColumns(SqlConnection connection, string tableName, string schema);

--- a/src/Connector.SqlServer/Connector/SqlClient.cs
+++ b/src/Connector.SqlServer/Connector/SqlClient.cs
@@ -78,7 +78,7 @@ namespace CluedIn.Connector.SqlServer.Connector
 
                     if (parsedPoolSize > 32767)
                     {
-                        configurationError = new ConnectionConfigurationError($"Connection pool size was set to a value higher than 32767");
+                        configurationError = new ConnectionConfigurationError("Connection pool size was set to a value higher than 32767");
                         return false;
                     }
                 }

--- a/src/Connector.SqlServer/Connector/SqlClient.cs
+++ b/src/Connector.SqlServer/Connector/SqlClient.cs
@@ -76,11 +76,9 @@ namespace CluedIn.Connector.SqlServer.Connector
                         return false;
                     }
 
-                    // Validate that connection pool size is not attempted to be set to bigger than 32767,
-                    // since that is the max value allowed by SQL server.
-                    if (parsedPoolSize > 32767)
+                    if (parsedPoolSize > _defaultConnectionPoolSize)
                     {
-                        configurationError = new ConnectionConfigurationError("Connection pool size was set to a value higher than 32767");
+                        configurationError = new ConnectionConfigurationError("Connection pool size was set to a value higher than 200");
                         return false;
                     }
                 }

--- a/src/Connector.SqlServer/Connector/SqlClient.cs
+++ b/src/Connector.SqlServer/Connector/SqlClient.cs
@@ -68,7 +68,21 @@ namespace CluedIn.Connector.SqlServer.Connector
 
             if (config.TryGetValue(SqlServerConstants.KeyName.ConnectionPoolSize, out var connectionPoolSizeEntry) && !string.IsNullOrEmpty(connectionPoolSizeEntry.ToString()))
             {
-                if (!int.TryParse(connectionPoolSizeEntry.ToString(), out _))
+                if (int.TryParse(connectionPoolSizeEntry.ToString(), out var parsedPoolSize))
+                {
+                    if (parsedPoolSize < 1)
+                    {
+                        configurationError = new ConnectionConfigurationError("Connection pool size was set to a value smaller than 1");
+                        return false;
+                    }
+
+                    if (parsedPoolSize > 32767)
+                    {
+                        configurationError = new ConnectionConfigurationError($"Connection pool size was set to a value higher than 32767");
+                        return false;
+                    }
+                }
+                else
                 {
                     configurationError = new ConnectionConfigurationError("Connection pool size was set, but could not be read as a number");
                     return false;

--- a/src/Connector.SqlServer/Connector/SqlClient.cs
+++ b/src/Connector.SqlServer/Connector/SqlClient.cs
@@ -76,6 +76,8 @@ namespace CluedIn.Connector.SqlServer.Connector
                         return false;
                     }
 
+                    // Validate that connection pool size is not attempted to be set to bigger than 32767,
+                    // since that is the max value allowed by SQL server.
                     if (parsedPoolSize > 32767)
                     {
                         configurationError = new ConnectionConfigurationError("Connection pool size was set to a value higher than 32767");

--- a/src/Connector.SqlServer/Connector/SqlClient.cs
+++ b/src/Connector.SqlServer/Connector/SqlClient.cs
@@ -11,6 +11,7 @@ namespace CluedIn.Connector.SqlServer.Connector
     public class SqlClient : ISqlClient
     {
         private readonly int _defaultPort = 1433;
+        private readonly int _defaultConnectionPoolSize = 200;
 
         public string BuildConnectionString(IReadOnlyDictionary<string, object> config)
         {
@@ -22,15 +23,60 @@ namespace CluedIn.Connector.SqlServer.Connector
                 DataSource = (string)config[SqlServerConstants.KeyName.Host],
                 InitialCatalog = (string)config[SqlServerConstants.KeyName.DatabaseName],
                 Pooling = true,
-                MaxPoolSize = 200
             };
 
-            if (config.TryGetValue(SqlServerConstants.KeyName.PortNumber, out var portEntry) && int.TryParse(portEntry.ToString(), out var port))
+            // Configure port
+            {
+                var port = _defaultPort;
+                if (config.TryGetValue(SqlServerConstants.KeyName.PortNumber, out var portEntry) &&
+                    !string.IsNullOrEmpty(portEntry.ToString()) &&
+                    int.TryParse(portEntry.ToString(), out var parsedPort))
+                {
+                    port = parsedPort;
+                }
+
                 connectionStringBuilder.DataSource = $"{connectionStringBuilder.DataSource},{port}";
-            else
-                connectionStringBuilder.DataSource = $"{connectionStringBuilder.DataSource},{_defaultPort}";
+            }
+
+            // Configure connection pool size
+            {
+                var connectionPoolSize = _defaultConnectionPoolSize;
+                if (config.TryGetValue(SqlServerConstants.KeyName.ConnectionPoolSize, out var connectionPoolSizeEntry) &&
+                    !string.IsNullOrEmpty(connectionPoolSizeEntry.ToString()) &&
+                    int.TryParse(connectionPoolSizeEntry.ToString(), out var parsedConnectionPoolSize))
+                {
+                    connectionPoolSize = parsedConnectionPoolSize;
+                }
+
+                connectionStringBuilder.MaxPoolSize = connectionPoolSize;
+            }
+
 
             return connectionStringBuilder.ToString();
+        }
+
+        public bool VerifyConnectionProperties(IReadOnlyDictionary<string, object> config, out ConnectionConfigurationError configurationError)
+        {
+            if (config.TryGetValue(SqlServerConstants.KeyName.PortNumber, out var portEntry) && !string.IsNullOrEmpty(portEntry.ToString()))
+            {
+                if (!int.TryParse(portEntry.ToString(), out _))
+                {
+                    configurationError = new ConnectionConfigurationError("Port number was set, but could not be read as a number");
+                    return false;
+                }
+            }
+
+            if (config.TryGetValue(SqlServerConstants.KeyName.ConnectionPoolSize, out var connectionPoolSizeEntry) && !string.IsNullOrEmpty(connectionPoolSizeEntry.ToString()))
+            {
+                if (!int.TryParse(connectionPoolSizeEntry.ToString(), out _))
+                {
+                    configurationError = new ConnectionConfigurationError("Connection pool size was set, but could not be read as a number");
+                    return false;
+                }
+            }
+
+            configurationError = null;
+            return true;
         }
 
         public async Task<SqlConnection> BeginConnection(IReadOnlyDictionary<string, object> config)

--- a/src/Connector.SqlServer/Connector/SqlServerConnector.cs
+++ b/src/Connector.SqlServer/Connector/SqlServerConnector.cs
@@ -308,6 +308,11 @@ namespace CluedIn.Connector.SqlServer.Connector
         {
             try
             {
+                if (!_client.VerifyConnectionProperties(configurationData, out var configurationError))
+                {
+                    return new ConnectionVerificationResult(success: false, errorMessage: configurationError.ErrorMessage);
+                }
+
                 await using var connectionAndTransaction = await _client.BeginTransaction(configurationData);
                 var connectionIsOpen = connectionAndTransaction.Connection.State == ConnectionState.Open;
                 await connectionAndTransaction.DisposeAsync();

--- a/src/Connector.SqlServer/SqlServerConstants.cs
+++ b/src/Connector.SqlServer/SqlServerConstants.cs
@@ -17,6 +17,7 @@ namespace CluedIn.Connector.SqlServer
             public const string Username = "username";
             public const string Password = "password";
             public const string PortNumber = "portNumber";
+            public const string ConnectionPoolSize = "connectionPoolSize";
         }
 
         public SqlServerConstants()

--- a/src/Connector.SqlServer/SqlServerConstants.cs
+++ b/src/Connector.SqlServer/SqlServerConstants.cs
@@ -104,6 +104,13 @@ namespace CluedIn.Connector.SqlServer
                     displayName = "Schema",
                     type = "input",
                     isRequired = false
+                },
+                new Control
+                {
+                    name = KeyName.ConnectionPoolSize,
+                    displayName = "Connection pool size",
+                    type = "input",
+                    isRequired = false
                 }
             }
         };

--- a/test/unit/Connector.SqlServer.Test/Connector/SqlClientTests.cs
+++ b/test/unit/Connector.SqlServer.Test/Connector/SqlClientTests.cs
@@ -163,5 +163,47 @@ namespace CluedIn.Connector.SqlServer.Unit.Tests.Connector
             result.Should().BeFalse();
             connectionConfigurationError.ErrorMessage.Should().Be("Connection pool size was set, but could not be read as a number");
         }
+
+        [Fact]
+        public void VerifyConnectionProperties_With0ConnectionPoolSize_ReturnsFalse()
+        {
+            // arrange
+            var properties = new Dictionary<string, object>
+            {
+                [SqlServerConstants.KeyName.Password] = "password",
+                [SqlServerConstants.KeyName.Username] = "user",
+                [SqlServerConstants.KeyName.Host] = "host",
+                [SqlServerConstants.KeyName.DatabaseName] = "database",
+                [SqlServerConstants.KeyName.ConnectionPoolSize] = "0",
+            };
+
+            // act
+            var result = _sut.VerifyConnectionProperties(properties, out var connectionConfigurationError);
+
+            // assert
+            result.Should().BeFalse();
+            connectionConfigurationError.ErrorMessage.Should().Be("Connection pool size was set to a value smaller than 1");
+        }
+
+        [Fact]
+        public void VerifyConnectionProperties_With32768ConnectionPoolSize_ReturnsFalse()
+        {
+            // arrange
+            var properties = new Dictionary<string, object>
+            {
+                [SqlServerConstants.KeyName.Password] = "password",
+                [SqlServerConstants.KeyName.Username] = "user",
+                [SqlServerConstants.KeyName.Host] = "host",
+                [SqlServerConstants.KeyName.DatabaseName] = "database",
+                [SqlServerConstants.KeyName.ConnectionPoolSize] = "32768",
+            };
+
+            // act
+            var result = _sut.VerifyConnectionProperties(properties, out var connectionConfigurationError);
+
+            // assert
+            result.Should().BeFalse();
+            connectionConfigurationError.ErrorMessage.Should().Be("Connection pool size was set to a value higher than 32767");
+        }
     }
 }

--- a/test/unit/Connector.SqlServer.Test/Connector/SqlClientTests.cs
+++ b/test/unit/Connector.SqlServer.Test/Connector/SqlClientTests.cs
@@ -186,7 +186,7 @@ namespace CluedIn.Connector.SqlServer.Unit.Tests.Connector
         }
 
         [Fact]
-        public void VerifyConnectionProperties_With32768ConnectionPoolSize_ReturnsFalse()
+        public void VerifyConnectionProperties_With201ConnectionPoolSize_ReturnsFalse()
         {
             // arrange
             var properties = new Dictionary<string, object>
@@ -195,7 +195,7 @@ namespace CluedIn.Connector.SqlServer.Unit.Tests.Connector
                 [SqlServerConstants.KeyName.Username] = "user",
                 [SqlServerConstants.KeyName.Host] = "host",
                 [SqlServerConstants.KeyName.DatabaseName] = "database",
-                [SqlServerConstants.KeyName.ConnectionPoolSize] = "32768",
+                [SqlServerConstants.KeyName.ConnectionPoolSize] = "201",
             };
 
             // act
@@ -203,7 +203,7 @@ namespace CluedIn.Connector.SqlServer.Unit.Tests.Connector
 
             // assert
             result.Should().BeFalse();
-            connectionConfigurationError.ErrorMessage.Should().Be("Connection pool size was set to a value higher than 32767");
+            connectionConfigurationError.ErrorMessage.Should().Be("Connection pool size was set to a value higher than 200");
         }
     }
 }


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#37975](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/37975)

Make connection pool size configurable. Also return better error message when port number is configured incorrectly.

## How has it been tested? <!-- Remove if not needed -->
Manually tested.
Added unit tests.

## Release Note <!-- Remove if not needed -->
feat: Make connection pool size configurable.