### PR TITLE
fix: Handle vocabulary property names being sanitized to the same names

### DIFF
--- a/src/Connector.SqlServer/Connector/SqlServerConnector.cs
+++ b/src/Connector.SqlServer/Connector/SqlServerConnector.cs
@@ -489,7 +489,7 @@ namespace CluedIn.Connector.SqlServer.Connector
 
         public override Task<string> GetValidMappingDestinationPropertyName(ExecutionContext executionContext, Guid connectorProviderDefinitionId, string propertyName)
         {
-            return Task.FromResult(propertyName.ToSanitizedSqlName());
+            return Task.FromResult(propertyName);
         }
 
         public override async Task RemoveContainer(ExecutionContext executionContext, IReadOnlyStreamModel streamModel)

--- a/src/Connector.SqlServer/Utils/TableDefinitions/MainTableDefinition.cs
+++ b/src/Connector.SqlServer/Utils/TableDefinitions/MainTableDefinition.cs
@@ -54,6 +54,9 @@ namespace CluedIn.Connector.SqlServer.Utils.TableDefinitions
             var propertyColumns = properties
                 // We need to filter out any properties, that are contained in the default columns.
                 .Where(property => !defaultColumnNamesHashSet.Contains(property.name.ToSanitizedSqlName()))
+                .OrderBy(property => property.dataType is VocabularyKeyConnectorPropertyDataType x
+                    ? $"{x.VocabularyKey.Vocabulary.KeyPrefix}.{x.VocabularyKey.Name}"
+                    : property.name)
                 .Select(property =>
                 {
                     var nameToUse = GetNameToUse(property, alreadyUsedNames);

--- a/test/unit/Connector.SqlServer.Test/Utils/TableDefinitions/MainTableDefinitionTests.cs
+++ b/test/unit/Connector.SqlServer.Test/Utils/TableDefinitions/MainTableDefinitionTests.cs
@@ -121,5 +121,32 @@ namespace CluedIn.Connector.SqlServer.Unit.Tests.Utils.TableDefinitions
             var sqlDateValue = discoveryDateColumnDefinition.GetValueFunc(sqlDiscoveryDatePropertyDate);
             sqlDateValue.Should().Be("2000-01-01T01:01:01.0000000+01:00");
         }
+
+        [Theory, AutoNData]
+        public void VocabularyPropertiesBeingSanitizedToTheSameName_ShouldHaveNumbersAddedAtTheEnd(
+            IVocabulary vocabulary1,
+            IVocabulary vocabulary2)
+        {
+            // arrange
+            vocabulary1.KeyPrefix = "test--vocabulary";
+            vocabulary2.KeyPrefix = "test-.vocabulary";
+            var vocabularyKey1 = new VocabularyKey("name") { Vocabulary = vocabulary1 };
+            var vocabularyKey2 = new VocabularyKey("name") { Vocabulary = vocabulary2 };
+
+            var properties = new (string, ConnectorPropertyDataType)[]
+            {
+                ("testvocabularyname", new VocabularyKeyConnectorPropertyDataType(vocabularyKey1)),
+                ("testvocabularyname", new VocabularyKeyConnectorPropertyDataType(vocabularyKey2)),
+            };
+
+            // act
+            var syncColumnDefinitions = MainTableDefinition.GetColumnDefinitions(StreamMode.Sync, properties);
+
+            // assert
+            var columnDefinitionNames = syncColumnDefinitions.Select(x => x.Name).ToList();
+
+            columnDefinitionNames.Should().Contain("testvocabularyname");
+            columnDefinitionNames.Should().Contain("testvocabularyname_1");
+        }
     }
 }

--- a/test/unit/Connector.SqlServer.Test/Utils/TableDefinitions/MainTableDefinitionTests.cs
+++ b/test/unit/Connector.SqlServer.Test/Utils/TableDefinitions/MainTableDefinitionTests.cs
@@ -148,5 +148,39 @@ namespace CluedIn.Connector.SqlServer.Unit.Tests.Utils.TableDefinitions
             columnDefinitionNames.Should().Contain("testvocabularyname");
             columnDefinitionNames.Should().Contain("testvocabularyname_1");
         }
+
+        [Theory, AutoNData]
+        public void DifferentOrderVocabularyProperties_ShouldNotImpactOrderOfColumnDefinition(
+            IVocabulary vocabulary1,
+            IVocabulary vocabulary2)
+        {
+            // arrange
+            vocabulary1.KeyPrefix = "test--vocabulary";
+            vocabulary2.KeyPrefix = "test-.vocabulary";
+            var vocabularyKey1 = new VocabularyKey("name") { Vocabulary = vocabulary1 };
+            var vocabularyKey2 = new VocabularyKey("name") { Vocabulary = vocabulary2 };
+
+            var properties1 = new (string, ConnectorPropertyDataType)[]
+            {
+                ("testvocabularyname", new VocabularyKeyConnectorPropertyDataType(vocabularyKey1)),
+                ("testvocabularyname", new VocabularyKeyConnectorPropertyDataType(vocabularyKey2)),
+            };
+
+            var properties2 = new (string, ConnectorPropertyDataType)[]
+            {
+                ("testvocabularyname", new VocabularyKeyConnectorPropertyDataType(vocabularyKey2)),
+                ("testvocabularyname", new VocabularyKeyConnectorPropertyDataType(vocabularyKey1)),
+            };
+
+            // act
+            var syncColumnDefinitions1 = MainTableDefinition.GetColumnDefinitions(StreamMode.Sync, properties1);
+            var syncColumnDefinitions2 = MainTableDefinition.GetColumnDefinitions(StreamMode.Sync, properties2);
+
+            // assert
+            var syncColumnDefinitions1Names = syncColumnDefinitions1.Select(x => (x.Name));
+            var syncColumnDefinitions2Names = syncColumnDefinitions2.Select(x => (x.Name));
+
+            syncColumnDefinitions1Names.Should().BeEquivalentTo(syncColumnDefinitions2Names);
+        }
     }
 }


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#37700](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/37700)

Three things of concern here: 

1. When we sanitize property names for use as column names, we can end up having duplicate names, which causes errors when trying to create main table. To handle this, when creating the names, check if name has already been used, and if so, add number at the end.
2. Order properties in the main table. This ensure that duplicate names, will always represent the same underlying property
3. Don't return sanitized name in `GetValidMappingDestinationPropertyName`. Since this method only takes one name at a time, we cannot add numbers to the end of duplicated names. If we return the sanitized name here, any properties with duplicated names when sanitized, will get the value from the first set, when adding rows in the main table. This change is not breaking, since the translated values are stored platform side.


## How has it been tested? <!-- Remove if not needed -->
Manually tested, and added unit test

## Release Note <!-- Remove if not needed -->
fix: Add number at the end of column names, if the names are duplicates
