### PR TITLE
fix: Add case for manually serializing entity type values

### DIFF
--- a/docs/4.1.1-release-notes.md
+++ b/docs/4.1.1-release-notes.md
@@ -1,2 +1,5 @@
 ### Features
 - Allow user to optionally configure connection pool size.
+
+### Fixes
+- Fix issue where entity type properties were not serialized correctly

--- a/src/Connector.SqlServer/Utils/TableDefinitions/MainTableDefinition.cs
+++ b/src/Connector.SqlServer/Utils/TableDefinitions/MainTableDefinition.cs
@@ -1,5 +1,6 @@
 ﻿using CluedIn.Connector.SqlServer.Connector;
 using CluedIn.Core.Connectors;
+using CluedIn.Core.Data;
 using CluedIn.Core.Streams.Models;
 using Microsoft.Data.SqlClient;
 using System;
@@ -86,6 +87,11 @@ namespace CluedIn.Connector.SqlServer.Utils.TableDefinitions
                             if (propertyValue is DateTimeOffset dateTimeOffsetValue)
                             {
                                 return dateTimeOffsetValue.ToString("O");
+                            }
+
+                            if (propertyValue is EntityType entityTypeValue)
+                            {
+                                return entityTypeValue.ToString();
                             }
 
                             return propertyValue;


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#43258](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/43258)

Add case for manually serializing entity type values. Without this, export will fail, since SqlClient can't serialize EntityType.

## How has it been tested? <!-- Remove if not needed -->
Manually and added unit tests.

## Release Note <!-- Remove if not needed -->
fix: Fix issue where entity type properties were not serialized correctly, leading storing data to fail