### PR TITLE
fix: Validate schema correctly, and fallback to default if empty string is specified

### DIFF
--- a/src/Connector.SqlServer/Connector/ISqlClient.cs
+++ b/src/Connector.SqlServer/Connector/ISqlClient.cs
@@ -11,6 +11,8 @@ namespace CluedIn.Connector.SqlServer.Connector
     {
         bool VerifyConnectionProperties(IReadOnlyDictionary<string, object> config, out ConnectionConfigurationError configurationError);
 
+        Task<bool> VerifySchemaExists(SqlTransaction transaction, string schema);
+
         Task<SqlConnection> BeginConnection(IReadOnlyDictionary<string, object> config);
 
         Task<DataTable> GetTableColumns(SqlConnection connection, string tableName, string schema);

--- a/src/Connector.SqlServer/Connector/SqlClient.cs
+++ b/src/Connector.SqlServer/Connector/SqlClient.cs
@@ -95,6 +95,7 @@ namespace CluedIn.Connector.SqlServer.Connector
 
         public async Task<bool> VerifySchemaExists(SqlTransaction transaction, string schema)
         {
+            // INFORMATION_SCHEMA.SCHEMATA contains all the views accessible to the current user in SQL Server.
             var schemaQuery = $"SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = '{schema}'";
 
             var command = transaction.Connection.CreateCommand();

--- a/src/Connector.SqlServer/Connector/SqlClient.cs
+++ b/src/Connector.SqlServer/Connector/SqlClient.cs
@@ -93,6 +93,20 @@ namespace CluedIn.Connector.SqlServer.Connector
             return true;
         }
 
+        public async Task<bool> VerifySchemaExists(SqlTransaction transaction, string schema)
+        {
+            var schemaQuery = $"SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = '{schema}'";
+
+            var command = transaction.Connection.CreateCommand();
+            command.CommandText = schemaQuery;
+            command.Transaction = transaction;
+
+            await using (var reader = await command.ExecuteReaderAsync())
+            {
+                return reader.HasRows;
+            }
+        }
+
         public async Task<SqlConnection> BeginConnection(IReadOnlyDictionary<string, object> config)
         {
             var connectionString = BuildConnectionString(config);

--- a/src/Connector.SqlServer/Connector/SqlServerConnector.cs
+++ b/src/Connector.SqlServer/Connector/SqlServerConnector.cs
@@ -318,6 +318,7 @@ namespace CluedIn.Connector.SqlServer.Connector
 
                 if (!connectionIsOpen)
                 {
+                    _logger.LogError("SqlServerConnector connection verification failed, connection could not be opened");
                     return new ConnectionVerificationResult(false);
                 }
 
@@ -327,11 +328,18 @@ namespace CluedIn.Connector.SqlServer.Connector
                     schema = SqlTableName.DefaultSchema;
                 }
 
+
                 var schemaExists = await _client.VerifySchemaExists(connectionAndTransaction.Transaction, schema);
 
                 await connectionAndTransaction.DisposeAsync();
 
-                return new ConnectionVerificationResult(schemaExists);
+                if (!schemaExists)
+                {
+                    _logger.LogError("SqlServerConnector connection verification failed, schema '{schema}' does not exist", schema);
+                    return new ConnectionVerificationResult(false);
+                }
+
+                return new ConnectionVerificationResult(true);
             }
             catch (Exception e)
             {

--- a/src/Connector.SqlServer/Utils/ConnectorConnectionExtensions.cs
+++ b/src/Connector.SqlServer/Utils/ConnectorConnectionExtensions.cs
@@ -9,14 +9,12 @@ namespace CluedIn.Connector.SqlServer.Utils
         /// </summary>
         public static SqlName GetSchema(this IConnectorConnectionV2 config)
         {
-            if (config.Authentication.TryGetValue(SqlServerConstants.KeyName.Schema, out var value) && value is string schema)
+            if (config.Authentication.TryGetValue(SqlServerConstants.KeyName.Schema, out var value) &&
+                value is string schema &&
+                !string.IsNullOrEmpty(schema))
             {
                 var sanitizedSchema = schema.ToSanitizedSqlName();
-
-                if (!string.IsNullOrEmpty(sanitizedSchema))
-                {
-                    return SqlName.FromSanitized(schema);
-                }
+                return SqlName.FromSanitized(sanitizedSchema);
             }
 
             return SqlName.FromSanitized(SqlTableName.DefaultSchema);


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#43949](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/43949), [AB#43956](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/43956)

2 parts:
- Add verification of schema in `VerifyConnection`. This will cause test connection to fail in UI, and export target to become unhealthy is incorrect schema is specified.
- Fix issue where if empty string was specified as schema, we would not fallback to default.

## How has it been tested? <!-- Remove if not needed -->
Manually by specifying empty schema, incorrect schema and correct schema, and streaming entity

## Release Note <!-- Remove if not needed -->
Fix issue where incorrectly specified schema results in entity not being streamed