### PR TITLE
fix: Convert PersonReference typed properties

### DIFF
--- a/src/Connector.SqlServer/Utils/TableDefinitions/MainTableDefinition.cs
+++ b/src/Connector.SqlServer/Utils/TableDefinitions/MainTableDefinition.cs
@@ -94,6 +94,11 @@ namespace CluedIn.Connector.SqlServer.Utils.TableDefinitions
                                 return entityTypeValue.ToString();
                             }
 
+                            if (propertyValue is PersonReference personReference)
+                            {
+                                return personReference.Name;
+                            }
+
                             return propertyValue;
                         },
                         CanBeNull: true);

--- a/src/Connector.SqlServer/Utils/TableDefinitions/MainTableDefinition.cs
+++ b/src/Connector.SqlServer/Utils/TableDefinitions/MainTableDefinition.cs
@@ -94,9 +94,12 @@ namespace CluedIn.Connector.SqlServer.Utils.TableDefinitions
                                 return entityTypeValue.ToString();
                             }
 
-                            if (propertyValue is PersonReference personReference)
+                            if (propertyValue is EntityReference entityReference)
                             {
-                                return personReference.Name;
+                                var codeString = entityReference.Code?.ToString();
+                                return !string.IsNullOrEmpty(codeString)
+                                    ? codeString
+                                    : entityReference.Name;
                             }
 
                             return propertyValue;


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#44676](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/44676)
Add case for converting `PersonReference` typed properties.

## How has it been tested? <!-- Remove if not needed -->
Manually tested and added unit test

## Release Note <!-- Remove if not needed -->
Fixes issue where entities with person references (such as those coming from manual data entry) will not be streamed.