### PR TITLE
chore: Turn off connection encryption requirement

### DIFF
--- a/src/Connector.SqlServer/Connector/SqlClient.cs
+++ b/src/Connector.SqlServer/Connector/SqlClient.cs
@@ -23,6 +23,9 @@ namespace CluedIn.Connector.SqlServer.Connector
                 DataSource = (string)config[SqlServerConstants.KeyName.Host],
                 InitialCatalog = (string)config[SqlServerConstants.KeyName.DatabaseName],
                 Pooling = true,
+                // Turn off unconditionally for now. Later maybe should be coming from configuration.
+                // Is needed as new SqlClient library encrypts by default.
+                Encrypt = false
             };
 
             // Configure port

--- a/test/unit/Connector.SqlServer.Test/Connector/SqlClientTests.cs
+++ b/test/unit/Connector.SqlServer.Test/Connector/SqlClientTests.cs
@@ -27,7 +27,7 @@ namespace CluedIn.Connector.SqlServer.Unit.Tests.Connector
 
             var result = _sut.BuildConnectionString(properties);
 
-            Assert.Equal("Data Source=host,1433;Initial Catalog=database;User ID=user;Password=password;Pooling=True;Max Pool Size=200;Authentication=SqlPassword", result);
+            Assert.Equal("Data Source=host,1433;Initial Catalog=database;User ID=user;Password=password;Pooling=True;Max Pool Size=200;Encrypt=False;Authentication=SqlPassword", result);
         }
 
         [Fact]
@@ -44,7 +44,7 @@ namespace CluedIn.Connector.SqlServer.Unit.Tests.Connector
 
             var result = _sut.BuildConnectionString(properties);
 
-            Assert.Equal("Data Source=host,9499;Initial Catalog=database;User ID=user;Password=password;Pooling=True;Max Pool Size=200;Authentication=SqlPassword", result);
+            Assert.Equal("Data Source=host,9499;Initial Catalog=database;User ID=user;Password=password;Pooling=True;Max Pool Size=200;Encrypt=False;Authentication=SqlPassword", result);
         }
 
         [Fact]
@@ -61,7 +61,7 @@ namespace CluedIn.Connector.SqlServer.Unit.Tests.Connector
 
             var result = _sut.BuildConnectionString(properties);
 
-            Assert.Equal("Data Source=host,9499;Initial Catalog=database;User ID=user;Password=password;Pooling=True;Max Pool Size=200;Authentication=SqlPassword", result);
+            Assert.Equal("Data Source=host,9499;Initial Catalog=database;User ID=user;Password=password;Pooling=True;Max Pool Size=200;Encrypt=False;Authentication=SqlPassword", result);
         }
 
         [Fact]
@@ -78,7 +78,7 @@ namespace CluedIn.Connector.SqlServer.Unit.Tests.Connector
 
             var result = _sut.BuildConnectionString(properties);
 
-            Assert.Equal("Data Source=host,1433;Initial Catalog=database;User ID=user;Password=password;Pooling=True;Max Pool Size=200;Authentication=SqlPassword", result);
+            Assert.Equal("Data Source=host,1433;Initial Catalog=database;User ID=user;Password=password;Pooling=True;Max Pool Size=200;Encrypt=False;Authentication=SqlPassword", result);
         }
 
         [Fact]
@@ -98,7 +98,7 @@ namespace CluedIn.Connector.SqlServer.Unit.Tests.Connector
             var result = _sut.BuildConnectionString(properties);
 
             // assert
-            Assert.Equal("Data Source=host,1433;Initial Catalog=database;User ID=user;Password=password;Pooling=True;Max Pool Size=10;Authentication=SqlPassword", result);
+            Assert.Equal("Data Source=host,1433;Initial Catalog=database;User ID=user;Password=password;Pooling=True;Max Pool Size=10;Encrypt=False;Authentication=SqlPassword", result);
         }
 
         [Fact] public void VerifyConnectionProperties_WithValidProperties_ReturnsTrue()


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#44188](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/44188)

Turn off encryption requirement, as now it's required by default

## How has it been tested? <!-- Remove if not needed -->
Tested manually

## Release Note <!-- Remove if not needed -->
Disable encryption requirement and verification to support update of SqlClient library