### PR TITLE
chore: Update platform dependency to 4.5.0

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup Label="Dependency Versions">
-    <_CluedIn>4.0.0</_CluedIn>
+    <_CluedIn>4.5.0-*</_CluedIn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Connector.SqlServer/Connector/SqlClient.cs
+++ b/src/Connector.SqlServer/Connector/SqlClient.cs
@@ -25,7 +25,7 @@ namespace CluedIn.Connector.SqlServer.Connector
                 Pooling = true,
                 // Turn off unconditionally for now. Later maybe should be coming from configuration.
                 // Is needed as new SqlClient library encrypts by default.
-                Encrypt = false
+                Encrypt = SqlConnectionEncryptOption.Optional
             };
 
             // Configure port


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#44188](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/44188)

Update platform dependency to latest 4.5.0.

It's needed because platform updated SQL Server client lib and it has a binary breaking change.

## How has it been tested? <!-- Remove if not needed -->
Tested manually

## Release Note <!-- Remove if not needed -->
Update platform dependency to 4.5.0
