### PR TITLE
feat: Ability to configure trust server certificate

### DIFF
--- a/docs/4.5.1-release-notes.md
+++ b/docs/4.5.1-release-notes.md
@@ -1,0 +1,2 @@
+### Features
+- Ability to configure Trust Server Certificate

--- a/docs/4.5.1-release-notes.md
+++ b/docs/4.5.1-release-notes.md
@@ -1,2 +1,2 @@
 ### Features
-- Ability to configure Trust Server Certificate
+- Ability to configure Trust Server Certificate. Note that enabling this option bypasses certificate validation and reduces TLS security (MITM risk), so it should only be used when necessary (for example in development or with self-signed certificates) and is not generally recommended for production use unless the implications are fully understood.

--- a/src/Connector.SqlServer/Connector/SqlClient.cs
+++ b/src/Connector.SqlServer/Connector/SqlClient.cs
@@ -31,7 +31,7 @@ namespace CluedIn.Connector.SqlServer.Connector
                 // Turn off unconditionally for now. Later maybe should be coming from configuration.
                 // Is needed as new SqlClient library encrypts by default.
                 Encrypt = SqlConnectionEncryptOption.Optional,
-                TrustServerCertificate = trustServerCertificate
+                TrustServerCertificate = trustServerCertificate,
             };
 
             // Configure port

--- a/src/Connector.SqlServer/Connector/SqlClient.cs
+++ b/src/Connector.SqlServer/Connector/SqlClient.cs
@@ -15,6 +15,11 @@ namespace CluedIn.Connector.SqlServer.Connector
 
         public string BuildConnectionString(IReadOnlyDictionary<string, object> config)
         {
+            var trustServerCertificate =
+                config.TryGetValue(SqlServerConstants.KeyName.TrustServerCertificate, out var value) &&
+                bool.TryParse(value?.ToString(), out var result) &&
+                result;
+
             var connectionStringBuilder = new SqlConnectionStringBuilder
             {
                 Authentication = SqlAuthenticationMethod.SqlPassword,
@@ -25,7 +30,8 @@ namespace CluedIn.Connector.SqlServer.Connector
                 Pooling = true,
                 // Turn off unconditionally for now. Later maybe should be coming from configuration.
                 // Is needed as new SqlClient library encrypts by default.
-                Encrypt = SqlConnectionEncryptOption.Optional
+                Encrypt = SqlConnectionEncryptOption.Optional,
+                TrustServerCertificate = trustServerCertificate
             };
 
             // Configure port

--- a/src/Connector.SqlServer/Connector/SqlClient.cs
+++ b/src/Connector.SqlServer/Connector/SqlClient.cs
@@ -15,11 +15,6 @@ namespace CluedIn.Connector.SqlServer.Connector
 
         public string BuildConnectionString(IReadOnlyDictionary<string, object> config)
         {
-            var trustServerCertificate =
-                config.TryGetValue(SqlServerConstants.KeyName.TrustServerCertificate, out var value) &&
-                bool.TryParse(value?.ToString(), out var result) &&
-                result;
-
             var connectionStringBuilder = new SqlConnectionStringBuilder
             {
                 Authentication = SqlAuthenticationMethod.SqlPassword,
@@ -33,9 +28,17 @@ namespace CluedIn.Connector.SqlServer.Connector
                 Encrypt = SqlConnectionEncryptOption.Optional
             };
 
-            if (trustServerCertificate)
+            // Configure trust server certificate
             {
-                connectionStringBuilder.TrustServerCertificate = true;
+                var trustServerCertificate =
+                    config.TryGetValue(SqlServerConstants.KeyName.TrustServerCertificate, out var value) &&
+                    bool.TryParse(value?.ToString(), out var result) &&
+                    result;
+
+                if (trustServerCertificate)
+                {
+                    connectionStringBuilder.TrustServerCertificate = true;
+                }
             }
 
             // Configure port

--- a/src/Connector.SqlServer/Connector/SqlClient.cs
+++ b/src/Connector.SqlServer/Connector/SqlClient.cs
@@ -30,9 +30,13 @@ namespace CluedIn.Connector.SqlServer.Connector
                 Pooling = true,
                 // Turn off unconditionally for now. Later maybe should be coming from configuration.
                 // Is needed as new SqlClient library encrypts by default.
-                Encrypt = SqlConnectionEncryptOption.Optional,
-                TrustServerCertificate = trustServerCertificate,
+                Encrypt = SqlConnectionEncryptOption.Optional
             };
+
+            if (trustServerCertificate)
+            {
+                connectionStringBuilder.TrustServerCertificate = true;
+            }
 
             // Configure port
             {

--- a/src/Connector.SqlServer/SqlServerConstants.cs
+++ b/src/Connector.SqlServer/SqlServerConstants.cs
@@ -18,6 +18,7 @@ namespace CluedIn.Connector.SqlServer
             public const string Password = "password";
             public const string PortNumber = "portNumber";
             public const string ConnectionPoolSize = "connectionPoolSize";
+            public const string TrustServerCertificate = "trustServerCertificate";
         }
 
         public SqlServerConstants()
@@ -110,6 +111,13 @@ namespace CluedIn.Connector.SqlServer
                     name = KeyName.ConnectionPoolSize,
                     displayName = "Connection pool size",
                     type = "input",
+                    isRequired = false
+                },
+                new Control
+                {
+                    name = KeyName.TrustServerCertificate,
+                    displayName = "Trust Server Certificate",
+                    type = "checkbox",
                     isRequired = false
                 }
             }

--- a/test/unit/Connector.SqlServer.Test/Connector/SqlClientTests.cs
+++ b/test/unit/Connector.SqlServer.Test/Connector/SqlClientTests.cs
@@ -23,11 +23,12 @@ namespace CluedIn.Connector.SqlServer.Unit.Tests.Connector
                 [SqlServerConstants.KeyName.Username] = "user",
                 [SqlServerConstants.KeyName.Host] = "host",
                 [SqlServerConstants.KeyName.DatabaseName] = "database",
+                [SqlServerConstants.KeyName.TrustServerCertificate] = true
             };
 
             var result = _sut.BuildConnectionString(properties);
 
-            Assert.Equal("Data Source=host,1433;Initial Catalog=database;User ID=user;Password=password;Pooling=True;Max Pool Size=200;Encrypt=False;Authentication=SqlPassword", result);
+            Assert.Equal("Data Source=host,1433;Initial Catalog=database;User ID=user;Password=password;Pooling=True;Max Pool Size=200;Encrypt=False;Trust Server Certificate=True;Authentication=SqlPassword", result);
         }
 
         [Fact]
@@ -44,7 +45,7 @@ namespace CluedIn.Connector.SqlServer.Unit.Tests.Connector
 
             var result = _sut.BuildConnectionString(properties);
 
-            Assert.Equal("Data Source=host,9499;Initial Catalog=database;User ID=user;Password=password;Pooling=True;Max Pool Size=200;Encrypt=False;Authentication=SqlPassword", result);
+            Assert.Equal("Data Source=host,9499;Initial Catalog=database;User ID=user;Password=password;Pooling=True;Max Pool Size=200;Encrypt=False;Trust Server Certificate=False;Authentication=SqlPassword", result);
         }
 
         [Fact]
@@ -61,7 +62,7 @@ namespace CluedIn.Connector.SqlServer.Unit.Tests.Connector
 
             var result = _sut.BuildConnectionString(properties);
 
-            Assert.Equal("Data Source=host,9499;Initial Catalog=database;User ID=user;Password=password;Pooling=True;Max Pool Size=200;Encrypt=False;Authentication=SqlPassword", result);
+            Assert.Equal("Data Source=host,9499;Initial Catalog=database;User ID=user;Password=password;Pooling=True;Max Pool Size=200;Encrypt=False;Trust Server Certificate=False;Authentication=SqlPassword", result);
         }
 
         [Fact]
@@ -78,7 +79,7 @@ namespace CluedIn.Connector.SqlServer.Unit.Tests.Connector
 
             var result = _sut.BuildConnectionString(properties);
 
-            Assert.Equal("Data Source=host,1433;Initial Catalog=database;User ID=user;Password=password;Pooling=True;Max Pool Size=200;Encrypt=False;Authentication=SqlPassword", result);
+            Assert.Equal("Data Source=host,1433;Initial Catalog=database;User ID=user;Password=password;Pooling=True;Max Pool Size=200;Encrypt=False;Trust Server Certificate=False;Authentication=SqlPassword", result);
         }
 
         [Fact]
@@ -98,7 +99,7 @@ namespace CluedIn.Connector.SqlServer.Unit.Tests.Connector
             var result = _sut.BuildConnectionString(properties);
 
             // assert
-            Assert.Equal("Data Source=host,1433;Initial Catalog=database;User ID=user;Password=password;Pooling=True;Max Pool Size=10;Encrypt=False;Authentication=SqlPassword", result);
+            Assert.Equal("Data Source=host,1433;Initial Catalog=database;User ID=user;Password=password;Pooling=True;Max Pool Size=10;Encrypt=False;Trust Server Certificate=False;Authentication=SqlPassword", result);
         }
 
         [Fact] public void VerifyConnectionProperties_WithValidProperties_ReturnsTrue()

--- a/test/unit/Connector.SqlServer.Test/Connector/SqlClientTests.cs
+++ b/test/unit/Connector.SqlServer.Test/Connector/SqlClientTests.cs
@@ -1,6 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using AutoFixture.Xunit2;
 using CluedIn.Connector.SqlServer.Connector;
 using FluentAssertions;
+using System.Collections.Generic;
 using Xunit;
 
 namespace CluedIn.Connector.SqlServer.Unit.Tests.Connector
@@ -23,12 +24,30 @@ namespace CluedIn.Connector.SqlServer.Unit.Tests.Connector
                 [SqlServerConstants.KeyName.Username] = "user",
                 [SqlServerConstants.KeyName.Host] = "host",
                 [SqlServerConstants.KeyName.DatabaseName] = "database",
-                [SqlServerConstants.KeyName.TrustServerCertificate] = true
             };
 
             var result = _sut.BuildConnectionString(properties);
 
-            Assert.Equal("Data Source=host,1433;Initial Catalog=database;User ID=user;Password=password;Pooling=True;Max Pool Size=200;Encrypt=False;Trust Server Certificate=True;Authentication=SqlPassword", result);
+            Assert.Equal("Data Source=host,1433;Initial Catalog=database;User ID=user;Password=password;Pooling=True;Max Pool Size=200;Encrypt=False;Authentication=SqlPassword", result);
+        }
+
+        [Theory]
+        [InlineAutoData(true)]
+        [InlineAutoData(false)]
+        public void BuildConnectionString_Sets_From_DictionaryEx(bool trustServerCertificate)
+        {
+            var properties = new Dictionary<string, object>
+            {
+                [SqlServerConstants.KeyName.Password] = "password",
+                [SqlServerConstants.KeyName.Username] = "user",
+                [SqlServerConstants.KeyName.Host] = "host",
+                [SqlServerConstants.KeyName.DatabaseName] = "database",
+                [SqlServerConstants.KeyName.TrustServerCertificate] = trustServerCertificate,
+            };
+
+            var result = _sut.BuildConnectionString(properties);
+
+            Assert.Equal($"Data Source=host,1433;Initial Catalog=database;User ID=user;Password=password;Pooling=True;Max Pool Size=200;Encrypt=False;{(trustServerCertificate ? "Trust Server Certificate=True;" : "")}Authentication=SqlPassword", result);
         }
 
         [Fact]
@@ -45,7 +64,7 @@ namespace CluedIn.Connector.SqlServer.Unit.Tests.Connector
 
             var result = _sut.BuildConnectionString(properties);
 
-            Assert.Equal("Data Source=host,9499;Initial Catalog=database;User ID=user;Password=password;Pooling=True;Max Pool Size=200;Encrypt=False;Trust Server Certificate=False;Authentication=SqlPassword", result);
+            Assert.Equal("Data Source=host,9499;Initial Catalog=database;User ID=user;Password=password;Pooling=True;Max Pool Size=200;Encrypt=False;Authentication=SqlPassword", result);
         }
 
         [Fact]
@@ -62,7 +81,7 @@ namespace CluedIn.Connector.SqlServer.Unit.Tests.Connector
 
             var result = _sut.BuildConnectionString(properties);
 
-            Assert.Equal("Data Source=host,9499;Initial Catalog=database;User ID=user;Password=password;Pooling=True;Max Pool Size=200;Encrypt=False;Trust Server Certificate=False;Authentication=SqlPassword", result);
+            Assert.Equal("Data Source=host,9499;Initial Catalog=database;User ID=user;Password=password;Pooling=True;Max Pool Size=200;Encrypt=False;Authentication=SqlPassword", result);
         }
 
         [Fact]
@@ -79,7 +98,7 @@ namespace CluedIn.Connector.SqlServer.Unit.Tests.Connector
 
             var result = _sut.BuildConnectionString(properties);
 
-            Assert.Equal("Data Source=host,1433;Initial Catalog=database;User ID=user;Password=password;Pooling=True;Max Pool Size=200;Encrypt=False;Trust Server Certificate=False;Authentication=SqlPassword", result);
+            Assert.Equal("Data Source=host,1433;Initial Catalog=database;User ID=user;Password=password;Pooling=True;Max Pool Size=200;Encrypt=False;Authentication=SqlPassword", result);
         }
 
         [Fact]
@@ -99,7 +118,7 @@ namespace CluedIn.Connector.SqlServer.Unit.Tests.Connector
             var result = _sut.BuildConnectionString(properties);
 
             // assert
-            Assert.Equal("Data Source=host,1433;Initial Catalog=database;User ID=user;Password=password;Pooling=True;Max Pool Size=10;Encrypt=False;Trust Server Certificate=False;Authentication=SqlPassword", result);
+            Assert.Equal("Data Source=host,1433;Initial Catalog=database;User ID=user;Password=password;Pooling=True;Max Pool Size=10;Encrypt=False;Authentication=SqlPassword", result);
         }
 
         [Fact] public void VerifyConnectionProperties_WithValidProperties_ReturnsTrue()


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#56354](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/56354)

New `Trust Server Certificate` Control
<img width="1907" height="938" alt="image" src="https://github.com/user-attachments/assets/e08e81dc-333a-4b9b-917c-ca734da502b1" />

Connection String containing `Trust Server Certificate`
<img width="1928" height="1044" alt="image" src="https://github.com/user-attachments/assets/860bde0c-e724-4e85-b912-d794da1a5885" />

Stream Event
<img width="1509" height="900" alt="image" src="https://github.com/user-attachments/assets/84d4e745-ec47-4c30-bc24-70a73f634cb5" />
<img width="1898" height="900" alt="image" src="https://github.com/user-attachments/assets/c50f9d6c-f3e6-484e-87f0-d1646910d351" />


## How has it been tested? <!-- Remove if not needed -->
Manually in local

